### PR TITLE
Implement validating webhook for LLMModel

### DIFF
--- a/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
+++ b/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
@@ -20,13 +20,17 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
+	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/controller/reconcilers"
 )
 
 // nolint:unused
@@ -36,11 +40,9 @@ var llmmodellog = logf.Log.WithName("llmmodel-resource")
 // SetupLLMModelWebhookWithManager registers the webhook for LLMModel in the manager.
 func SetupLLMModelWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&llmv1alpha1.LLMModel{}).
-		WithValidator(&LLMModelCustomValidator{}).
+		WithValidator(&LLMModelCustomValidator{Client: mgr.GetClient()}).
 		Complete()
 }
-
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
@@ -53,46 +55,160 @@ func SetupLLMModelWebhookWithManager(mgr ctrl.Manager) error {
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
 type LLMModelCustomValidator struct {
-	// TODO(user): Add more fields as needed for validation
+	Client client.Client
 }
 
 var _ webhook.CustomValidator = &LLMModelCustomValidator{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type LLMModel.
-func (v *LLMModelCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (v *LLMModelCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	llmmodel, ok := obj.(*llmv1alpha1.LLMModel)
 	if !ok {
 		return nil, fmt.Errorf("expected a LLMModel object but got %T", obj)
 	}
 	llmmodellog.Info("Validation for LLMModel upon creation", "name", llmmodel.GetName())
 
-	// TODO(user): fill in your validation logic upon object creation.
+	if err := v.validateNamespaceLabel(ctx, llmmodel.Namespace); err != nil {
+		return nil, err
+	}
 
-	return nil, nil
+	subdomain, err := effectiveSubdomain(llmmodel)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v.validateSubdomainCollision(ctx, subdomain, llmmodel.Namespace, llmmodel.Name); err != nil {
+		return nil, err
+	}
+
+	warnings := emptyDirPreloadWarnings(llmmodel)
+
+	return warnings, nil
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type LLMModel.
-func (v *LLMModelCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (v *LLMModelCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	llmmodel, ok := newObj.(*llmv1alpha1.LLMModel)
 	if !ok {
 		return nil, fmt.Errorf("expected a LLMModel object for the newObj but got %T", newObj)
 	}
 	llmmodellog.Info("Validation for LLMModel upon update", "name", llmmodel.GetName())
 
-	// TODO(user): fill in your validation logic upon object update.
+	if err := v.validateNamespaceLabel(ctx, llmmodel.Namespace); err != nil {
+		return nil, err
+	}
 
-	return nil, nil
+	subdomain, err := effectiveSubdomain(llmmodel)
+	if err != nil {
+		return nil, err
+	}
+
+	// Exclude the model being updated from the collision check.
+	if err := v.validateSubdomainCollision(ctx, subdomain, llmmodel.Namespace, llmmodel.Name); err != nil {
+		return nil, err
+	}
+
+	warnings := emptyDirPreloadWarnings(llmmodel)
+
+	return warnings, nil
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type LLMModel.
-func (v *LLMModelCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (v *LLMModelCustomValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
 	llmmodel, ok := obj.(*llmv1alpha1.LLMModel)
 	if !ok {
 		return nil, fmt.Errorf("expected a LLMModel object but got %T", obj)
 	}
 	llmmodellog.Info("Validation for LLMModel upon deletion", "name", llmmodel.GetName())
 
-	// TODO(user): fill in your validation logic upon object deletion.
-
 	return nil, nil
+}
+
+// validateNamespaceLabel checks that the given namespace has the nebari.dev/managed=true label.
+func (v *LLMModelCustomValidator) validateNamespaceLabel(ctx context.Context, namespaceName string) error {
+	var ns corev1.Namespace
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: namespaceName}, &ns); err != nil {
+		return fmt.Errorf("failed to get namespace %q: %w", namespaceName, err)
+	}
+
+	if ns.Labels["nebari.dev/managed"] != "true" {
+		return fmt.Errorf(
+			"namespace %q does not have the required label nebari.dev/managed=true; "+
+				"LLMModel resources can only be created in namespaces managed by Nebari",
+			namespaceName,
+		)
+	}
+
+	return nil
+}
+
+// effectiveSubdomain returns the subdomain that will be used for this LLMModel.
+// It uses spec.endpoints.external.subdomain if set, otherwise it slugifies the model name.
+// It also validates that the result does not exceed 63 characters.
+func effectiveSubdomain(llmmodel *llmv1alpha1.LLMModel) (string, error) {
+	subdomain := llmmodel.Spec.Endpoints.External.Subdomain
+	if subdomain == "" {
+		subdomain = reconcilers.Slugify(llmmodel.Name)
+	}
+
+	if len(subdomain) > 63 {
+		return "", fmt.Errorf(
+			"effective subdomain %q is %d characters long; subdomains must be 63 characters or fewer",
+			subdomain, len(subdomain),
+		)
+	}
+
+	return subdomain, nil
+}
+
+// validateSubdomainCollision checks that no other LLMModel across all namespaces
+// uses the same effective subdomain. The model identified by (excludeNamespace, excludeName)
+// is excluded from the check (used for updates).
+func (v *LLMModelCustomValidator) validateSubdomainCollision(
+	ctx context.Context,
+	subdomain, excludeNamespace, excludeName string,
+) error {
+	var modelList llmv1alpha1.LLMModelList
+	if err := v.Client.List(ctx, &modelList); err != nil {
+		return fmt.Errorf("failed to list LLMModels for subdomain collision check: %w", err)
+	}
+
+	for i := range modelList.Items {
+		existing := &modelList.Items[i]
+
+		// Skip the model being created/updated.
+		if existing.Namespace == excludeNamespace && existing.Name == excludeName {
+			continue
+		}
+
+		existingSubdomain, err := effectiveSubdomain(existing)
+		if err != nil {
+			// If an existing model has an invalid subdomain, skip it rather than
+			// blocking new creates.
+			continue
+		}
+
+		if existingSubdomain == subdomain {
+			return fmt.Errorf(
+				"subdomain %q is already in use by LLMModel %s/%s; each model must have a unique subdomain",
+				subdomain, existing.Namespace, existing.Name,
+			)
+		}
+	}
+
+	return nil
+}
+
+// emptyDirPreloadWarnings returns a warning if the model uses emptyDir storage with preload enabled.
+func emptyDirPreloadWarnings(llmmodel *llmv1alpha1.LLMModel) admission.Warnings {
+	if llmmodel.Spec.Model.Storage.Type == llmv1alpha1.StorageTypeEmptyDir &&
+		llmmodel.Spec.Model.Preload != nil &&
+		*llmmodel.Spec.Model.Preload {
+		return admission.Warnings{
+			"storage type is emptyDir with preload=true: every pod restart triggers a re-download of the model, " +
+				"which may cause significant delays and bandwidth usage; consider using a PVC for persistent storage",
+		}
+	}
+
+	return nil
 }

--- a/operator/internal/webhook/v1alpha1/llmmodel_webhook_test.go
+++ b/operator/internal/webhook/v1alpha1/llmmodel_webhook_test.go
@@ -17,55 +17,290 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
-	// TODO (user): Add any additional imports if needed
 )
+
+// newManagedNamespace creates a namespace with the nebari.dev/managed=true label.
+func newManagedNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"nebari.dev/managed": "true",
+			},
+		},
+	}
+}
+
+// newUnmanagedNamespace creates a namespace without the nebari.dev/managed label.
+func newUnmanagedNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// newBaseLLMModel returns a minimal valid LLMModel in the given namespace.
+func newBaseLLMModel(name, namespace string) *llmv1alpha1.LLMModel {
+	return &llmv1alpha1.LLMModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: llmv1alpha1.LLMModelSpec{
+			Model: llmv1alpha1.ModelSpec{
+				Name:   "mistralai/Mistral-7B-v0.1",
+				Source: llmv1alpha1.ModelSourceHuggingFace,
+			},
+			Resources: llmv1alpha1.ResourceSpec{
+				GPU: llmv1alpha1.GPUSpec{
+					Count: 1,
+					Type:  "nvidia",
+				},
+			},
+			Access: llmv1alpha1.AccessSpec{
+				Groups: []string{"data-scientists"},
+			},
+		},
+	}
+}
 
 var _ = Describe("LLMModel Webhook", func() {
 	var (
-		obj       *llmv1alpha1.LLMModel
-		oldObj    *llmv1alpha1.LLMModel
-		validator LLMModelCustomValidator
+		bgCtx = context.Background()
 	)
 
-	BeforeEach(func() {
-		obj = &llmv1alpha1.LLMModel{}
-		oldObj = &llmv1alpha1.LLMModel{}
-		validator = LLMModelCustomValidator{}
-		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
-		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
-		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		// TODO (user): Add any setup logic common to all tests
+	Context("ValidateCreate", func() {
+		It("should accept a valid LLMModel in a managed namespace", func() {
+			ns := newManagedNamespace("test-managed-create-valid")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			model := newBaseLLMModel("my-model", ns.Name)
+			Expect(k8sClient.Create(bgCtx, model)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, model) })
+		})
+
+		It("should reject a LLMModel in a namespace without the managed label", func() {
+			ns := newUnmanagedNamespace("test-unmanaged-create")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			model := newBaseLLMModel("my-model-unmanaged", ns.Name)
+			err := k8sClient.Create(bgCtx, model)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("nebari.dev/managed"))
+		})
+
+		It("should accept a LLMModel with an explicit valid subdomain", func() {
+			ns := newManagedNamespace("test-managed-explicit-subdomain")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			model := newBaseLLMModel("my-model-explicit", ns.Name)
+			model.Spec.Endpoints.External.Subdomain = "my-custom-subdomain"
+			Expect(k8sClient.Create(bgCtx, model)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, model) })
+		})
+
+		It("should reject a LLMModel whose effective subdomain exceeds 63 characters", func() {
+			ns := newManagedNamespace("test-managed-long-subdomain")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			// An explicit subdomain that is 64 chars long - too long.
+			longSubdomain := strings.Repeat("a", 64)
+			model := newBaseLLMModel("my-model-long-sub", ns.Name)
+			model.Spec.Endpoints.External.Subdomain = longSubdomain
+			err := k8sClient.Create(bgCtx, model)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("63"))
+		})
+
+		It("should reject a second LLMModel whose subdomain collides with an existing one", func() {
+			ns := newManagedNamespace("test-managed-collision")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			// First model: explicit subdomain "shared-subdomain"
+			first := newBaseLLMModel("first-model-collision", ns.Name)
+			first.Spec.Endpoints.External.Subdomain = "shared-subdomain"
+			Expect(k8sClient.Create(bgCtx, first)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, first) })
+
+			// Second model in a different namespace but same subdomain.
+			ns2 := newManagedNamespace("test-managed-collision2")
+			Expect(k8sClient.Create(bgCtx, ns2)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns2) })
+
+			second := newBaseLLMModel("second-model-collision", ns2.Name)
+			second.Spec.Endpoints.External.Subdomain = "shared-subdomain"
+			err := k8sClient.Create(bgCtx, second)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("subdomain"))
+		})
+
+		It("should accept but warn when storage type is emptyDir and preload is true", func() {
+			ns := newManagedNamespace("test-managed-emptydir-warn")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			preload := true
+			model := newBaseLLMModel("my-model-emptydir", ns.Name)
+			model.Spec.Model.Storage.Type = llmv1alpha1.StorageTypeEmptyDir
+			model.Spec.Model.Preload = &preload
+
+			// The create should succeed (warnings don't block).
+			Expect(k8sClient.Create(bgCtx, model)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, model) })
+		})
 	})
 
-	AfterEach(func() {
-		// TODO (user): Add any teardown logic common to all tests
+	Context("ValidateUpdate", func() {
+		It("should reject an update that causes a subdomain collision", func() {
+			ns := newManagedNamespace("test-managed-update-collision")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			// Create the first model to claim the subdomain.
+			first := newBaseLLMModel("update-first", ns.Name)
+			first.Spec.Endpoints.External.Subdomain = "taken-subdomain"
+			Expect(k8sClient.Create(bgCtx, first)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, first) })
+
+			// Create the second model with a different subdomain.
+			second := newBaseLLMModel("update-second", ns.Name)
+			second.Spec.Endpoints.External.Subdomain = "free-subdomain"
+			Expect(k8sClient.Create(bgCtx, second)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, second) })
+
+			// Now update second to collide with first.
+			second.Spec.Endpoints.External.Subdomain = "taken-subdomain"
+			err := k8sClient.Update(bgCtx, second)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("subdomain"))
+		})
+
+		It("should allow an update that keeps the same subdomain (self-update)", func() {
+			ns := newManagedNamespace("test-managed-update-self")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			model := newBaseLLMModel("update-self-model", ns.Name)
+			model.Spec.Endpoints.External.Subdomain = "my-own-subdomain"
+			Expect(k8sClient.Create(bgCtx, model)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, model) })
+
+			// Update an unrelated field; subdomain stays the same.
+			model.Spec.Access.Groups = []string{"updated-group"}
+			Expect(k8sClient.Update(bgCtx, model)).To(Succeed())
+		})
+
+		It("should reject an update when namespace loses managed label", func() {
+			ns := newManagedNamespace("test-managed-update-ns-label")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			model := newBaseLLMModel("update-ns-label-model", ns.Name)
+			Expect(k8sClient.Create(bgCtx, model)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, model) })
+
+			// Remove the managed label from the namespace.
+			ns.Labels = nil
+			Expect(k8sClient.Update(bgCtx, ns)).To(Succeed())
+
+			// Now try to update the model - should be rejected.
+			model.Spec.Access.Groups = []string{"some-other-group"}
+			err := k8sClient.Update(bgCtx, model)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("nebari.dev/managed"))
+		})
 	})
 
-	Context("When creating or updating LLMModel under Validating Webhook", func() {
-		// TODO (user): Add logic for validating webhooks
-		// Example:
-		// It("Should deny creation if a required field is missing", func() {
-		//     By("simulating an invalid creation scenario")
-		//     obj.SomeRequiredField = ""
-		//     Expect(validator.ValidateCreate(ctx, obj)).Error().To(HaveOccurred())
-		// })
-		//
-		// It("Should admit creation if all required fields are present", func() {
-		//     By("simulating an invalid creation scenario")
-		//     obj.SomeRequiredField = "valid_value"
-		//     Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())
-		// })
-		//
-		// It("Should validate updates correctly", func() {
-		//     By("simulating a valid update scenario")
-		//     oldObj.SomeRequiredField = "updated_value"
-		//     obj.SomeRequiredField = "updated_value"
-		//     Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil())
-		// })
+	Context("ValidateDelete", func() {
+		It("should always accept deletion", func() {
+			ns := newManagedNamespace("test-managed-delete")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			model := newBaseLLMModel("delete-model", ns.Name)
+			Expect(k8sClient.Create(bgCtx, model)).To(Succeed())
+
+			Expect(k8sClient.Delete(bgCtx, model)).To(Succeed())
+		})
 	})
 
+	Context("Unit-level validator tests (no envtest)", func() {
+		// These test the validator struct directly to verify warning logic
+		// without going through the full webhook server round-trip.
+		var validator *LLMModelCustomValidator
+
+		BeforeEach(func() {
+			validator = &LLMModelCustomValidator{Client: k8sClient}
+		})
+
+		It("should return a warning when storage is emptyDir and preload is true", func() {
+			preload := true
+			model := newBaseLLMModel("warn-unit", "default")
+			model.Spec.Model.Storage.Type = llmv1alpha1.StorageTypeEmptyDir
+			model.Spec.Model.Preload = &preload
+
+			ns := newManagedNamespace(fmt.Sprintf("warn-unit-ns-%s", "default"))
+			// We can't create this without envtest here; just call the
+			// validator method directly with an existing managed namespace.
+			// Use the pre-existing "default" namespace in envtest (it won't
+			// have the label, so we'll test the emptyDir warning path via a
+			// managed namespace created specifically for this).
+			managedNs := newManagedNamespace("unit-warn-ns")
+			Expect(k8sClient.Create(bgCtx, managedNs)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, managedNs) })
+			_ = ns
+
+			model.Namespace = managedNs.Name
+			warnings, err := validator.ValidateCreate(bgCtx, model)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).NotTo(BeEmpty())
+			Expect(warnings[0]).To(ContainSubstring("re-download"))
+		})
+
+		It("should not warn when storage is emptyDir but preload is false", func() {
+			preload := false
+			model := newBaseLLMModel("no-warn-unit", "unit-no-warn-ns")
+			model.Spec.Model.Storage.Type = llmv1alpha1.StorageTypeEmptyDir
+			model.Spec.Model.Preload = &preload
+
+			managedNs := newManagedNamespace("unit-no-warn-ns")
+			Expect(k8sClient.Create(bgCtx, managedNs)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, managedNs) })
+
+			warnings, err := validator.ValidateCreate(bgCtx, model)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should not warn when storage is pvc and preload is true", func() {
+			preload := true
+			model := newBaseLLMModel("no-warn-pvc", "unit-pvc-warn-ns")
+			model.Spec.Model.Storage.Type = llmv1alpha1.StorageTypePVC
+			model.Spec.Model.Preload = &preload
+
+			managedNs := newManagedNamespace("unit-pvc-warn-ns")
+			Expect(k8sClient.Create(bgCtx, managedNs)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, managedNs) })
+
+			warnings, err := validator.ValidateCreate(bgCtx, model)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Implements the validating webhook for LLMModel CRDs with:

- Namespace label check: rejects LLMModels in namespaces without `nebari.dev/managed=true`
- Subdomain generation: uses explicit subdomain or slugifies the model name
- Subdomain collision detection: lists all LLMModels cluster-wide, rejects duplicates
- DNS label length validation: rejects subdomains exceeding 63 chars
- emptyDir + preload warning: warns (doesn't reject) about re-download risk
- Self-exclusion on updates: a model's own subdomain doesn't count as a collision

Closes #4

## Test plan

13 Ginkgo specs covering all validation paths:
- `cd operator && go test ./internal/webhook/... -v` - all 13 specs pass
- `cd operator && make test` - full suite passes (81.7% webhook coverage)