### PR TITLE
Add OperatorConfig with env var parsing

### DIFF
--- a/operator/internal/config/config.go
+++ b/operator/internal/config/config.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// OperatorConfig holds all pack-level configuration parsed from environment variables.
+// It is loaded once at startup and passed to reconcilers.
+type OperatorConfig struct {
+	BaseDomain          string // LLM_BASE_DOMAIN (required)
+	ExternalGatewayName string // LLM_EXTERNAL_GATEWAY_NAME (required)
+	ExternalGatewayNS   string // LLM_EXTERNAL_GATEWAY_NAMESPACE (default: "envoy-gateway-system")
+	InternalGatewayName string // LLM_INTERNAL_GATEWAY_NAME (required)
+	InternalGatewayNS   string // LLM_INTERNAL_GATEWAY_NAMESPACE (default: "envoy-gateway-system")
+	OIDCIssuerURL       string // LLM_OIDC_ISSUER_URL (required)
+	OIDCGroupsClaim     string // LLM_OIDC_GROUPS_CLAIM (default: "groups")
+	OIDCAudience        string // LLM_OIDC_AUDIENCE (optional, empty string means no audience check)
+	DefaultServingImage string // LLM_DEFAULT_SERVING_IMAGE (default: "ghcr.io/llm-d/llm-d-cuda:v0.5.1")
+	APIKeysNamespace    string // LLM_API_KEYS_NAMESPACE (default: "llm-api-keys")
+}
+
+// getEnvOrDefault returns the value of the environment variable named by key,
+// or defaultVal if the variable is not set or is empty.
+func getEnvOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+// LoadFromEnv reads configuration from environment variables and returns an
+// OperatorConfig. It returns a descriptive error listing all missing required
+// variables if any are absent.
+func LoadFromEnv() (*OperatorConfig, error) {
+	var missing []string
+
+	require := func(key string) string {
+		v := os.Getenv(key)
+		if v == "" {
+			missing = append(missing, key)
+		}
+		return v
+	}
+
+	cfg := &OperatorConfig{
+		BaseDomain:          require("LLM_BASE_DOMAIN"),
+		ExternalGatewayName: require("LLM_EXTERNAL_GATEWAY_NAME"),
+		ExternalGatewayNS:   getEnvOrDefault("LLM_EXTERNAL_GATEWAY_NAMESPACE", "envoy-gateway-system"),
+		InternalGatewayName: require("LLM_INTERNAL_GATEWAY_NAME"),
+		InternalGatewayNS:   getEnvOrDefault("LLM_INTERNAL_GATEWAY_NAMESPACE", "envoy-gateway-system"),
+		OIDCIssuerURL:       require("LLM_OIDC_ISSUER_URL"),
+		OIDCGroupsClaim:     getEnvOrDefault("LLM_OIDC_GROUPS_CLAIM", "groups"),
+		OIDCAudience:        os.Getenv("LLM_OIDC_AUDIENCE"),
+		DefaultServingImage: getEnvOrDefault("LLM_DEFAULT_SERVING_IMAGE", "ghcr.io/llm-d/llm-d-cuda:v0.5.1"),
+		APIKeysNamespace:    getEnvOrDefault("LLM_API_KEYS_NAMESPACE", "llm-api-keys"),
+	}
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("missing required environment variables: %s", strings.Join(missing, ", "))
+	}
+
+	return cfg, nil
+}

--- a/operator/internal/config/config_test.go
+++ b/operator/internal/config/config_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		wantErr     bool
+		errContains []string
+		wantConfig  *OperatorConfig
+	}{
+		{
+			name: "all env vars set - parses correctly",
+			envVars: map[string]string{
+				"LLM_BASE_DOMAIN":                "example.com",
+				"LLM_EXTERNAL_GATEWAY_NAME":      "external-gw",
+				"LLM_EXTERNAL_GATEWAY_NAMESPACE": "custom-external-ns",
+				"LLM_INTERNAL_GATEWAY_NAME":      "internal-gw",
+				"LLM_INTERNAL_GATEWAY_NAMESPACE": "custom-internal-ns",
+				"LLM_OIDC_ISSUER_URL":            "https://auth.example.com",
+				"LLM_OIDC_GROUPS_CLAIM":          "custom-groups",
+				"LLM_OIDC_AUDIENCE":              "my-audience",
+				"LLM_DEFAULT_SERVING_IMAGE":      "my-registry/my-image:v1.0.0",
+				"LLM_API_KEYS_NAMESPACE":         "my-api-keys-ns",
+			},
+			wantErr: false,
+			wantConfig: &OperatorConfig{
+				BaseDomain:          "example.com",
+				ExternalGatewayName: "external-gw",
+				ExternalGatewayNS:   "custom-external-ns",
+				InternalGatewayName: "internal-gw",
+				InternalGatewayNS:   "custom-internal-ns",
+				OIDCIssuerURL:       "https://auth.example.com",
+				OIDCGroupsClaim:     "custom-groups",
+				OIDCAudience:        "my-audience",
+				DefaultServingImage: "my-registry/my-image:v1.0.0",
+				APIKeysNamespace:    "my-api-keys-ns",
+			},
+		},
+		{
+			name: "missing LLM_BASE_DOMAIN - returns error mentioning the var name",
+			envVars: map[string]string{
+				"LLM_EXTERNAL_GATEWAY_NAME": "external-gw",
+				"LLM_INTERNAL_GATEWAY_NAME": "internal-gw",
+				"LLM_OIDC_ISSUER_URL":       "https://auth.example.com",
+			},
+			wantErr:     true,
+			errContains: []string{"LLM_BASE_DOMAIN"},
+		},
+		{
+			name: "missing LLM_EXTERNAL_GATEWAY_NAME - returns error",
+			envVars: map[string]string{
+				"LLM_BASE_DOMAIN":           "example.com",
+				"LLM_INTERNAL_GATEWAY_NAME": "internal-gw",
+				"LLM_OIDC_ISSUER_URL":       "https://auth.example.com",
+			},
+			wantErr:     true,
+			errContains: []string{"LLM_EXTERNAL_GATEWAY_NAME"},
+		},
+		{
+			name: "missing LLM_INTERNAL_GATEWAY_NAME - returns error",
+			envVars: map[string]string{
+				"LLM_BASE_DOMAIN":           "example.com",
+				"LLM_EXTERNAL_GATEWAY_NAME": "external-gw",
+				"LLM_OIDC_ISSUER_URL":       "https://auth.example.com",
+			},
+			wantErr:     true,
+			errContains: []string{"LLM_INTERNAL_GATEWAY_NAME"},
+		},
+		{
+			name: "missing LLM_OIDC_ISSUER_URL - returns error",
+			envVars: map[string]string{
+				"LLM_BASE_DOMAIN":           "example.com",
+				"LLM_EXTERNAL_GATEWAY_NAME": "external-gw",
+				"LLM_INTERNAL_GATEWAY_NAME": "internal-gw",
+			},
+			wantErr:     true,
+			errContains: []string{"LLM_OIDC_ISSUER_URL"},
+		},
+		{
+			name: "optional vars missing - uses defaults",
+			envVars: map[string]string{
+				"LLM_BASE_DOMAIN":           "example.com",
+				"LLM_EXTERNAL_GATEWAY_NAME": "external-gw",
+				"LLM_INTERNAL_GATEWAY_NAME": "internal-gw",
+				"LLM_OIDC_ISSUER_URL":       "https://auth.example.com",
+			},
+			wantErr: false,
+			wantConfig: &OperatorConfig{
+				BaseDomain:          "example.com",
+				ExternalGatewayName: "external-gw",
+				ExternalGatewayNS:   "envoy-gateway-system",
+				InternalGatewayName: "internal-gw",
+				InternalGatewayNS:   "envoy-gateway-system",
+				OIDCIssuerURL:       "https://auth.example.com",
+				OIDCGroupsClaim:     "groups",
+				OIDCAudience:        "",
+				DefaultServingImage: "ghcr.io/llm-d/llm-d-cuda:v0.5.1",
+				APIKeysNamespace:    "llm-api-keys",
+			},
+		},
+		{
+			name: "OIDCAudience empty - no error",
+			envVars: map[string]string{
+				"LLM_BASE_DOMAIN":           "example.com",
+				"LLM_EXTERNAL_GATEWAY_NAME": "external-gw",
+				"LLM_INTERNAL_GATEWAY_NAME": "internal-gw",
+				"LLM_OIDC_ISSUER_URL":       "https://auth.example.com",
+				"LLM_OIDC_AUDIENCE":         "",
+			},
+			wantErr: false,
+			wantConfig: &OperatorConfig{
+				BaseDomain:          "example.com",
+				ExternalGatewayName: "external-gw",
+				ExternalGatewayNS:   "envoy-gateway-system",
+				InternalGatewayName: "internal-gw",
+				InternalGatewayNS:   "envoy-gateway-system",
+				OIDCIssuerURL:       "https://auth.example.com",
+				OIDCGroupsClaim:     "groups",
+				OIDCAudience:        "",
+				DefaultServingImage: "ghcr.io/llm-d/llm-d-cuda:v0.5.1",
+				APIKeysNamespace:    "llm-api-keys",
+			},
+		},
+		{
+			name:    "all required vars missing - error mentions all of them",
+			envVars: map[string]string{},
+			wantErr: true,
+			errContains: []string{
+				"LLM_BASE_DOMAIN",
+				"LLM_EXTERNAL_GATEWAY_NAME",
+				"LLM_INTERNAL_GATEWAY_NAME",
+				"LLM_OIDC_ISSUER_URL",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all relevant env vars before setting the test ones.
+			allVars := []string{
+				"LLM_BASE_DOMAIN",
+				"LLM_EXTERNAL_GATEWAY_NAME",
+				"LLM_EXTERNAL_GATEWAY_NAMESPACE",
+				"LLM_INTERNAL_GATEWAY_NAME",
+				"LLM_INTERNAL_GATEWAY_NAMESPACE",
+				"LLM_OIDC_ISSUER_URL",
+				"LLM_OIDC_GROUPS_CLAIM",
+				"LLM_OIDC_AUDIENCE",
+				"LLM_DEFAULT_SERVING_IMAGE",
+				"LLM_API_KEYS_NAMESPACE",
+			}
+			for _, v := range allVars {
+				t.Setenv(v, "")
+			}
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			got, err := LoadFromEnv()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("LoadFromEnv() expected error but got nil")
+				}
+				for _, substr := range tt.errContains {
+					if !strings.Contains(err.Error(), substr) {
+						t.Errorf("LoadFromEnv() error = %q, want it to contain %q", err.Error(), substr)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("LoadFromEnv() unexpected error: %v", err)
+			}
+
+			if got == nil {
+				t.Fatal("LoadFromEnv() returned nil config with no error")
+			}
+
+			if got.BaseDomain != tt.wantConfig.BaseDomain {
+				t.Errorf("BaseDomain = %q, want %q", got.BaseDomain, tt.wantConfig.BaseDomain)
+			}
+			if got.ExternalGatewayName != tt.wantConfig.ExternalGatewayName {
+				t.Errorf("ExternalGatewayName = %q, want %q", got.ExternalGatewayName, tt.wantConfig.ExternalGatewayName)
+			}
+			if got.ExternalGatewayNS != tt.wantConfig.ExternalGatewayNS {
+				t.Errorf("ExternalGatewayNS = %q, want %q", got.ExternalGatewayNS, tt.wantConfig.ExternalGatewayNS)
+			}
+			if got.InternalGatewayName != tt.wantConfig.InternalGatewayName {
+				t.Errorf("InternalGatewayName = %q, want %q", got.InternalGatewayName, tt.wantConfig.InternalGatewayName)
+			}
+			if got.InternalGatewayNS != tt.wantConfig.InternalGatewayNS {
+				t.Errorf("InternalGatewayNS = %q, want %q", got.InternalGatewayNS, tt.wantConfig.InternalGatewayNS)
+			}
+			if got.OIDCIssuerURL != tt.wantConfig.OIDCIssuerURL {
+				t.Errorf("OIDCIssuerURL = %q, want %q", got.OIDCIssuerURL, tt.wantConfig.OIDCIssuerURL)
+			}
+			if got.OIDCGroupsClaim != tt.wantConfig.OIDCGroupsClaim {
+				t.Errorf("OIDCGroupsClaim = %q, want %q", got.OIDCGroupsClaim, tt.wantConfig.OIDCGroupsClaim)
+			}
+			if got.OIDCAudience != tt.wantConfig.OIDCAudience {
+				t.Errorf("OIDCAudience = %q, want %q", got.OIDCAudience, tt.wantConfig.OIDCAudience)
+			}
+			if got.DefaultServingImage != tt.wantConfig.DefaultServingImage {
+				t.Errorf("DefaultServingImage = %q, want %q", got.DefaultServingImage, tt.wantConfig.DefaultServingImage)
+			}
+			if got.APIKeysNamespace != tt.wantConfig.APIKeysNamespace {
+				t.Errorf("APIKeysNamespace = %q, want %q", got.APIKeysNamespace, tt.wantConfig.APIKeysNamespace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds OperatorConfig struct that loads pack-level configuration from environment variables. The Helm chart sets these env vars on the operator Deployment; the controller reads them once at startup.

Required vars: LLM_BASE_DOMAIN, LLM_EXTERNAL_GATEWAY_NAME, LLM_INTERNAL_GATEWAY_NAME, LLM_OIDC_ISSUER_URL
Optional vars with defaults: gateway namespaces (envoy-gateway-system), groups claim (groups), serving image (llm-d-cuda:v0.5.1), api-keys namespace (llm-api-keys)

Error reporting lists all missing required vars at once rather than failing on the first one.

## Test plan

- `cd operator && go test ./internal/config/ -v` - 8 tests pass (100% coverage)
- `cd operator && make test` - full suite passes