### PR TITLE
Implement NetworkPolicy reconciler (default-deny, allow Gateway/EPP/Prometheus)

### DIFF
--- a/operator/internal/controller/reconcilers/networkpolicy.go
+++ b/operator/internal/controller/reconcilers/networkpolicy.go
@@ -1,0 +1,110 @@
+package reconcilers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
+	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
+)
+
+// BuildNetworkPolicy returns a NetworkPolicy for the model pods that enforces
+// default-deny ingress, allowing traffic only from the Envoy Gateway namespaces,
+// EPP pods in the same namespace, and Prometheus in the monitoring namespace.
+func BuildNetworkPolicy(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig) *networkingv1.NetworkPolicy {
+	labels := StandardLabels(model)
+
+	ingressRules := buildNetworkPolicyIngressRules(cfg)
+
+	policyTypeIngress := networkingv1.PolicyTypeIngress
+
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      model.Name + "-deny-direct",
+			Namespace: model.Namespace,
+			Labels:    labels,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/instance": model.Name,
+					"llm.nebari.dev/model":       model.Name,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{policyTypeIngress},
+			Ingress:     ingressRules,
+		},
+	}
+}
+
+func buildNetworkPolicyIngressRules(cfg *config.OperatorConfig) []networkingv1.NetworkPolicyIngressRule {
+	var rules []networkingv1.NetworkPolicyIngressRule
+
+	// Allow from gateway namespaces. Deduplicate if both gateways are in the same namespace.
+	gatewayNamespaces := uniqueStrings(cfg.ExternalGatewayNS, cfg.InternalGatewayNS)
+	for _, ns := range gatewayNamespaces {
+		rules = append(rules, networkingv1.NetworkPolicyIngressRule{
+			From: []networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": ns,
+						},
+					},
+				},
+			},
+		})
+	}
+
+	// Allow from EPP pods in same namespace (no namespaceSelector means same namespace).
+	rules = append(rules, networkingv1.NetworkPolicyIngressRule{
+		From: []networkingv1.NetworkPolicyPeer{
+			{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/name": "epp",
+					},
+				},
+			},
+		},
+	})
+
+	// Allow from monitoring namespace on port 8000 only.
+	tcpProto := corev1.ProtocolTCP
+	port8000 := intstr.FromInt32(8000)
+	rules = append(rules, networkingv1.NetworkPolicyIngressRule{
+		From: []networkingv1.NetworkPolicyPeer{
+			{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"kubernetes.io/metadata.name": "monitoring",
+					},
+				},
+			},
+		},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{
+				Protocol: &tcpProto,
+				Port:     &port8000,
+			},
+		},
+	})
+
+	return rules
+}
+
+// uniqueStrings returns a slice of unique strings preserving order,
+// omitting empty strings and duplicates.
+func uniqueStrings(values ...string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, v := range values {
+		if v != "" && !seen[v] {
+			seen[v] = true
+			result = append(result, v)
+		}
+	}
+	return result
+}

--- a/operator/internal/controller/reconcilers/networkpolicy_test.go
+++ b/operator/internal/controller/reconcilers/networkpolicy_test.go
@@ -1,0 +1,254 @@
+package reconcilers
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
+	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
+)
+
+func defaultNetworkPolicyConfig() *config.OperatorConfig {
+	return &config.OperatorConfig{
+		BaseDomain:          "example.com",
+		ExternalGatewayName: "external-gw",
+		ExternalGatewayNS:   "envoy-gateway-system",
+		InternalGatewayName: "internal-gw",
+		InternalGatewayNS:   "envoy-gateway-system",
+		OIDCIssuerURL:       "https://oidc.example.com",
+		DefaultServingImage: "ghcr.io/llm-d/llm-d-cuda:v0.5.1",
+	}
+}
+
+func defaultNetworkPolicyModel(name string) *llmv1alpha1.LLMModel {
+	return &llmv1alpha1.LLMModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "model-ns",
+		},
+		Spec: llmv1alpha1.LLMModelSpec{
+			Model: llmv1alpha1.ModelSpec{
+				Name:   "mistralai/Mistral-7B-v0.1",
+				Source: llmv1alpha1.ModelSourceHuggingFace,
+			},
+			Resources: llmv1alpha1.ResourceSpec{
+				GPU: llmv1alpha1.GPUSpec{Count: 1, Type: "nvidia"},
+			},
+		},
+	}
+}
+
+// hasNamespaceRule checks whether the policy's ingress rules contain a namespaceSelector
+// matching the given namespace name label value.
+func hasNamespaceRule(ingress []networkingv1.NetworkPolicyIngressRule, ns string) bool {
+	for _, rule := range ingress {
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil {
+				if v, ok := peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; ok && v == ns {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// hasPodSelectorRule checks whether the policy's ingress rules contain a podSelector
+// matching the given label key/value.
+func hasPodSelectorRule(ingress []networkingv1.NetworkPolicyIngressRule, key, value string) bool {
+	for _, rule := range ingress {
+		for _, peer := range rule.From {
+			if peer.PodSelector != nil {
+				if v, ok := peer.PodSelector.MatchLabels[key]; ok && v == value {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// countNamespaceRules counts how many ingress rules have a namespaceSelector matching the given ns.
+func countNamespaceRules(ingress []networkingv1.NetworkPolicyIngressRule, ns string) int {
+	count := 0
+	for _, rule := range ingress {
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil {
+				if v, ok := peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; ok && v == ns {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+func TestBuildNetworkPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		model *llmv1alpha1.LLMModel
+		cfg   *config.OperatorConfig
+		check func(t *testing.T, np *networkingv1.NetworkPolicy)
+	}{
+		{
+			name:  "policy name is <model-name>-deny-direct",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg:   defaultNetworkPolicyConfig(),
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				if np.Name != "my-model-deny-direct" {
+					t.Errorf("expected name %q, got %q", "my-model-deny-direct", np.Name)
+				}
+			},
+		},
+		{
+			name:  "policy namespace matches model namespace",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg:   defaultNetworkPolicyConfig(),
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				if np.Namespace != "model-ns" {
+					t.Errorf("expected namespace %q, got %q", "model-ns", np.Namespace)
+				}
+			},
+		},
+		{
+			name:  "podSelector matches model pods via StandardLabels subset",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg:   defaultNetworkPolicyConfig(),
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				sel := np.Spec.PodSelector.MatchLabels
+				if sel["app.kubernetes.io/instance"] != "my-model" {
+					t.Errorf("expected podSelector app.kubernetes.io/instance=my-model, got %v", sel)
+				}
+				if sel["llm.nebari.dev/model"] != "my-model" {
+					t.Errorf("expected podSelector llm.nebari.dev/model=my-model, got %v", sel)
+				}
+			},
+		},
+		{
+			name:  "policyTypes includes Ingress",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg:   defaultNetworkPolicyConfig(),
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				found := false
+				for _, pt := range np.Spec.PolicyTypes {
+					if pt == networkingv1.PolicyTypeIngress {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("expected PolicyTypes to include Ingress, got %v", np.Spec.PolicyTypes)
+				}
+			},
+		},
+		{
+			name:  "allows ingress from external gateway namespace",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg: &config.OperatorConfig{
+				ExternalGatewayNS: "external-gw-ns",
+				InternalGatewayNS: "internal-gw-ns",
+			},
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				if !hasNamespaceRule(np.Spec.Ingress, "external-gw-ns") {
+					t.Errorf("expected ingress rule allowing from external-gw-ns namespace")
+				}
+			},
+		},
+		{
+			name:  "allows ingress from internal gateway namespace",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg: &config.OperatorConfig{
+				ExternalGatewayNS: "external-gw-ns",
+				InternalGatewayNS: "internal-gw-ns",
+			},
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				if !hasNamespaceRule(np.Spec.Ingress, "internal-gw-ns") {
+					t.Errorf("expected ingress rule allowing from internal-gw-ns namespace")
+				}
+			},
+		},
+		{
+			name:  "when both gateway namespaces are the same only one namespace rule exists",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg: &config.OperatorConfig{
+				ExternalGatewayNS: "envoy-gateway-system",
+				InternalGatewayNS: "envoy-gateway-system",
+			},
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				count := countNamespaceRules(np.Spec.Ingress, "envoy-gateway-system")
+				if count != 1 {
+					t.Errorf("expected exactly 1 namespace rule for envoy-gateway-system when both gateways share a namespace, got %d", count)
+				}
+			},
+		},
+		{
+			name:  "allows ingress from EPP pods via podSelector",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg:   defaultNetworkPolicyConfig(),
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				if !hasPodSelectorRule(np.Spec.Ingress, "app.kubernetes.io/name", "epp") {
+					t.Errorf("expected ingress rule allowing from pods with app.kubernetes.io/name=epp")
+				}
+			},
+		},
+		{
+			name:  "allows ingress from monitoring namespace on port 8000 only",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg:   defaultNetworkPolicyConfig(),
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				found := false
+				for _, rule := range np.Spec.Ingress {
+					for _, peer := range rule.From {
+						if peer.NamespaceSelector != nil {
+							if v, ok := peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; ok && v == "monitoring" {
+								// Verify port restriction
+								if len(rule.Ports) != 1 {
+									t.Errorf("expected exactly 1 port in monitoring rule, got %d", len(rule.Ports))
+								} else {
+									port := rule.Ports[0]
+									if port.Port == nil || port.Port.IntValue() != 8000 {
+										t.Errorf("expected port 8000 in monitoring rule, got %v", port.Port)
+									}
+									if port.Protocol == nil || *port.Protocol != "TCP" {
+										t.Errorf("expected protocol TCP in monitoring rule, got %v", port.Protocol)
+									}
+								}
+								found = true
+							}
+						}
+					}
+				}
+				if !found {
+					t.Errorf("expected ingress rule allowing from monitoring namespace")
+				}
+			},
+		},
+		{
+			name:  "labels set to StandardLabels",
+			model: defaultNetworkPolicyModel("my-model"),
+			cfg:   defaultNetworkPolicyConfig(),
+			check: func(t *testing.T, np *networkingv1.NetworkPolicy) {
+				expected := StandardLabels(defaultNetworkPolicyModel("my-model"))
+				for k, v := range expected {
+					if np.Labels[k] != v {
+						t.Errorf("expected label %q=%q, got %q", k, v, np.Labels[k])
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			np := BuildNetworkPolicy(tt.model, tt.cfg)
+			if np == nil {
+				t.Fatal("expected non-nil NetworkPolicy")
+			}
+			tt.check(t, np)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Pure function `BuildNetworkPolicy` that creates a default-deny NetworkPolicy for model pods, allowing ingress only from:

- Envoy Gateway namespaces (external + internal, deduplicated if same)
- EPP pods in the same namespace (podSelector)
- Monitoring namespace on port 8000 (Prometheus scraping)

This makes the Gateway the only path to model pods. Direct Service access from other in-cluster workloads is blocked. The NetworkPolicy is always created, not conditional.

## Test plan

- `cd operator && go test ./internal/controller/reconcilers/ -v -run TestBuildNetworkPolicy` - 10 tests pass
- `cd operator && make test` - full suite passes (95% reconcilers coverage)