### PR TITLE
Implement main LLMModel controller orchestrating all reconcilers

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
+	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
 	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/controller"
 	webhookv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/webhook/v1alpha1"
 	// +kubebuilder:scaffold:imports
@@ -179,9 +180,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	operatorCfg, err := config.LoadFromEnv()
+	if err != nil {
+		setupLog.Error(err, "unable to load operator config")
+		os.Exit(1)
+	}
+
 	if err := (&controller.LLMModelReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		Config: operatorCfg,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LLMModel")
 		os.Exit(1)

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -5,6 +5,35 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  - persistentvolumeclaims
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - llm.nebari.dev
   resources:
   - llmmodels
@@ -30,3 +59,28 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/operator/internal/controller/llmmodel_controller.go
+++ b/operator/internal/controller/llmmodel_controller.go
@@ -18,46 +18,744 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
+	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
+	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
+	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/controller/reconcilers"
 )
+
+const (
+	finalizerName       = "llm.nebari.dev/cleanup"
+	modelConfigHashAnno = "llm.nebari.dev/model-config-hash"
+)
+
+// controllerLogger is the interface for structured logging used within this controller.
+type controllerLogger interface {
+	Info(msg string, keysAndValues ...interface{})
+	Error(err error, msg string, keysAndValues ...interface{})
+}
 
 // LLMModelReconciler reconciles a LLMModel object
 type LLMModelReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	Config *config.OperatorConfig
 }
 
 // +kubebuilder:rbac:groups=llm.nebari.dev,resources=llmmodels,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=llm.nebari.dev,resources=llmmodels/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=llm.nebari.dev,resources=llmmodels/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services;serviceaccounts;persistentvolumeclaims;secrets;configmaps;namespaces,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the LLMModel object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.22.1/pkg/reconcile
+// Reconcile implements the main reconciliation loop for LLMModel resources.
 func (r *LLMModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = logf.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
-	// TODO(user): your logic here
+	// 1. Fetch LLMModel
+	model := &llmv1alpha1.LLMModel{}
+	if err := r.Get(ctx, req.NamespacedName, model); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// 2. Handle deletion
+	if !model.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, model)
+	}
+
+	// 3. Add finalizer if missing
+	if !controllerutil.ContainsFinalizer(model, finalizerName) {
+		controllerutil.AddFinalizer(model, finalizerName)
+		if err := r.Update(ctx, model); err != nil {
+			return ctrl.Result{}, fmt.Errorf("adding finalizer: %w", err)
+		}
+		// Re-fetch after update to avoid stale resource version
+		if err := r.Get(ctx, req.NamespacedName, model); err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+	}
+
+	// 4. Set phase to Pending if empty
+	if model.Status.Phase == "" {
+		model.Status.Phase = llmv1alpha1.PhasePending
+		if err := r.Status().Update(ctx, model); err != nil {
+			log.Error(err, "failed to update status phase to Pending")
+		}
+	}
+
+	// 5. Ensure the llm-api-keys namespace exists (if Config is available)
+	if r.Config != nil {
+		if err := r.ensureNamespace(ctx, r.Config.APIKeysNamespace); err != nil {
+			return ctrl.Result{}, fmt.Errorf("ensuring api-keys namespace: %w", err)
+		}
+	}
+
+	// 6. Reconcile storage (PVC)
+	storageResult, err := reconcilers.BuildStorageSpec(model)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("building storage spec: %w", err)
+	}
+	if storageResult.PVC != nil {
+		storageResult.PVC.Namespace = model.Namespace
+		if err := reconcilers.SetOwnerReference(model, storageResult.PVC, r.Scheme); err != nil {
+			return ctrl.Result{}, fmt.Errorf("setting owner on PVC: %w", err)
+		}
+		if err := r.createOrUpdatePVC(ctx, storageResult.PVC); err != nil {
+			return ctrl.Result{}, fmt.Errorf("reconciling PVC: %w", err)
+		}
+	}
+
+	// 7. Reconcile auth resources (cross-namespace: Secret, ConfigMap, ReferenceGrant)
+	var authResources *reconcilers.AuthResources
+	if r.Config != nil {
+		authResources, err = reconcilers.BuildAuthResources(model, r.Config)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("building auth resources: %w", err)
+		}
+		if err := r.reconcileCrossNamespaceResources(ctx, log, authResources); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// 8. Reconcile NetworkPolicy
+	networkPolicy := reconcilers.BuildNetworkPolicy(model, r.Config)
+	if err := reconcilers.SetOwnerReference(model, networkPolicy, r.Scheme); err != nil {
+		return ctrl.Result{}, fmt.Errorf("setting owner on NetworkPolicy: %w", err)
+	}
+	if err := r.createOrUpdateNetworkPolicy(ctx, networkPolicy); err != nil {
+		return ctrl.Result{}, fmt.Errorf("reconciling NetworkPolicy: %w", err)
+	}
+
+	// 9. Reconcile model service resources (Deployment, Service, SA, PodMonitor)
+	modelServiceResources, err := reconcilers.BuildModelServiceResources(model, storageResult, r.Config)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("building model service resources: %w", err)
+	}
+	if err := r.reconcileModelServiceResources(ctx, log, model, modelServiceResources); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// 10. Check deployment readiness to determine phase
+	phase := r.determinePhase(ctx, model)
+	if phase == llmv1alpha1.PhaseDownloading || phase == llmv1alpha1.PhaseStarting {
+		model.Status.Phase = phase
+		if err := r.Status().Update(ctx, model); err != nil {
+			log.Error(err, "failed to update status phase", "phase", phase)
+		}
+		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	}
+
+	// 11. Once model is (or will be) serving, create downstream resources
+	if r.Config != nil {
+		// InferencePool + EPP
+		poolResources, err := reconcilers.BuildInferencePoolResources(model, r.Config)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("building inference pool resources: %w", err)
+		}
+		if err := r.reconcileInferencePoolResources(ctx, log, model, poolResources); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Routing (AIGatewayRoutes)
+		routingResources, err := reconcilers.BuildRoutingResources(model, r.Config)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("building routing resources: %w", err)
+		}
+		if err := r.reconcileRoutingResources(ctx, log, model, routingResources); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// SecurityPolicies (from auth resources built in step 7)
+		if authResources != nil {
+			if err := r.reconcileSecurityPolicies(ctx, log, authResources); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	// 12. Update status
+	if err := r.updateStatus(ctx, log, model, phase); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	return ctrl.Result{}, nil
+}
+
+// reconcileDelete handles finalization: cleans up cross-namespace resources and removes the finalizer.
+func (r *LLMModelReconciler) reconcileDelete(ctx context.Context, model *llmv1alpha1.LLMModel) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	if !controllerutil.ContainsFinalizer(model, finalizerName) {
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("cleaning up cross-namespace resources", "model", model.Name)
+
+	if r.Config != nil {
+		// Delete Secret in api-keys namespace
+		secret := &corev1.Secret{}
+		secretKey := types.NamespacedName{
+			Name:      reconcilers.APIKeySecretName(model.Name),
+			Namespace: r.Config.APIKeysNamespace,
+		}
+		if err := r.Get(ctx, secretKey, secret); err == nil {
+			if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("deleting api key secret: %w", err)
+			}
+		}
+
+		// Delete ConfigMap in api-keys namespace
+		cm := &corev1.ConfigMap{}
+		cmKey := types.NamespacedName{
+			Name:      reconcilers.APIKeyMetadataConfigMapName(model.Name),
+			Namespace: r.Config.APIKeysNamespace,
+		}
+		if err := r.Get(ctx, cmKey, cm); err == nil {
+			if err := r.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("deleting api key metadata configmap: %w", err)
+			}
+		}
+
+		// Delete ReferenceGrant in api-keys namespace
+		refGrant := &unstructured.Unstructured{}
+		refGrant.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "gateway.networking.k8s.io",
+			Version: "v1beta1",
+			Kind:    "ReferenceGrant",
+		})
+		refGrantKey := types.NamespacedName{
+			Name:      model.Name + "-" + model.Namespace + "-ref-grant",
+			Namespace: r.Config.APIKeysNamespace,
+		}
+		if err := r.Get(ctx, refGrantKey, refGrant); err == nil {
+			if err := r.Delete(ctx, refGrant); err != nil && !apierrors.IsNotFound(err) {
+				// Non-fatal: CRD may not be installed
+				log.Error(err, "failed to delete ReferenceGrant during cleanup")
+			}
+		}
+	}
+
+	// Remove finalizer
+	controllerutil.RemoveFinalizer(model, finalizerName)
+	if err := r.Update(ctx, model); err != nil {
+		return ctrl.Result{}, fmt.Errorf("removing finalizer: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// ensureNamespace creates the namespace if it does not exist.
+func (r *LLMModelReconciler) ensureNamespace(ctx context.Context, name string) error {
+	ns := &corev1.Namespace{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+		if err := r.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// reconcileCrossNamespaceResources creates or updates the Secret, ConfigMap, and
+// ReferenceGrant in the api-keys namespace. These resources have no owner references
+// and are cleaned up by the finalizer.
+func (r *LLMModelReconciler) reconcileCrossNamespaceResources(
+	ctx context.Context,
+	log controllerLogger,
+	auth *reconcilers.AuthResources,
+) error {
+	if err := r.createOrUpdateSecret(ctx, auth.APIKeySecret); err != nil {
+		return fmt.Errorf("reconciling api key secret: %w", err)
+	}
+	if err := r.createOrUpdateConfigMap(ctx, auth.APIKeyMetadataCM); err != nil {
+		return fmt.Errorf("reconciling api key metadata configmap: %w", err)
+	}
+	if auth.ReferenceGrant != nil {
+		if err := r.createOrUpdateUnstructured(ctx, log, auth.ReferenceGrant); err != nil {
+			log.Error(err, "failed to reconcile ReferenceGrant - CRD may not be installed, skipping")
+		}
+	}
+	return nil
+}
+
+// reconcileModelServiceResources creates or updates the Deployment, Service, SA, and PodMonitor.
+// It includes breaking-change detection for the Deployment.
+func (r *LLMModelReconciler) reconcileModelServiceResources(
+	ctx context.Context,
+	log controllerLogger,
+	model *llmv1alpha1.LLMModel,
+	resources *reconcilers.ModelServiceResources,
+) error {
+	// ServiceAccount
+	resources.ServiceAccount.Namespace = model.Namespace
+	if err := reconcilers.SetOwnerReference(model, resources.ServiceAccount, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner on ServiceAccount: %w", err)
+	}
+	if err := r.createOrUpdateServiceAccount(ctx, resources.ServiceAccount); err != nil {
+		return fmt.Errorf("reconciling ServiceAccount: %w", err)
+	}
+
+	// Service
+	resources.Service.Namespace = model.Namespace
+	if err := reconcilers.SetOwnerReference(model, resources.Service, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner on Service: %w", err)
+	}
+	if err := r.createOrUpdateService(ctx, resources.Service); err != nil {
+		return fmt.Errorf("reconciling Service: %w", err)
+	}
+
+	// Deployment - with breaking-change detection
+	resources.Deployment.Namespace = model.Namespace
+	if err := reconcilers.SetOwnerReference(model, resources.Deployment, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner on Deployment: %w", err)
+	}
+	hash := modelConfigHash(model)
+	if resources.Deployment.Annotations == nil {
+		resources.Deployment.Annotations = make(map[string]string)
+	}
+	resources.Deployment.Annotations[modelConfigHashAnno] = hash
+
+	existing := &appsv1.Deployment{}
+	getErr := r.Get(ctx, types.NamespacedName{Name: resources.Deployment.Name, Namespace: resources.Deployment.Namespace}, existing)
+	if getErr != nil && !apierrors.IsNotFound(getErr) {
+		return fmt.Errorf("getting existing Deployment: %w", getErr)
+	}
+	if getErr == nil {
+		// Deployment exists - check for breaking changes
+		existingHash := existing.Annotations[modelConfigHashAnno]
+		if existingHash != "" && existingHash != hash {
+			log.Info("model config changed - deleting Deployment to trigger re-download",
+				"old-hash", existingHash, "new-hash", hash)
+			if err := r.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf("deleting stale Deployment: %w", err)
+			}
+			// Will be re-created on next reconcile
+			return nil
+		}
+		// Update spec while preserving resource version
+		existing.Spec = resources.Deployment.Spec
+		if existing.Annotations == nil {
+			existing.Annotations = make(map[string]string)
+		}
+		existing.Annotations[modelConfigHashAnno] = hash
+		if err := r.Update(ctx, existing); err != nil {
+			return fmt.Errorf("updating Deployment: %w", err)
+		}
+	} else {
+		// Create new deployment
+		if err := r.Create(ctx, resources.Deployment); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("creating Deployment: %w", err)
+		}
+	}
+
+	// PodMonitor (optional CRD)
+	if resources.PodMonitor != nil {
+		resources.PodMonitor.SetNamespace(model.Namespace)
+		if err := r.createOrUpdateUnstructured(ctx, log, resources.PodMonitor); err != nil {
+			log.Error(err, "failed to reconcile PodMonitor - CRD may not be installed, skipping")
+		}
+	}
+
+	return nil
+}
+
+// reconcileInferencePoolResources creates or updates InferencePool and EPP resources.
+func (r *LLMModelReconciler) reconcileInferencePoolResources(
+	ctx context.Context,
+	log controllerLogger,
+	model *llmv1alpha1.LLMModel,
+	pool *reconcilers.InferencePoolResources,
+) error {
+	// InferencePool (unstructured CRD - non-fatal if missing)
+	pool.InferencePool.SetNamespace(model.Namespace)
+	if err := r.createOrUpdateUnstructured(ctx, log, pool.InferencePool); err != nil {
+		log.Error(err, "failed to reconcile InferencePool - CRD may not be installed, skipping")
+	}
+
+	// EPP ServiceAccount
+	pool.EPPServiceAccount.Namespace = model.Namespace
+	if err := reconcilers.SetOwnerReference(model, pool.EPPServiceAccount, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner on EPP ServiceAccount: %w", err)
+	}
+	if err := r.createOrUpdateServiceAccount(ctx, pool.EPPServiceAccount); err != nil {
+		return fmt.Errorf("reconciling EPP ServiceAccount: %w", err)
+	}
+
+	// EPP Role
+	pool.EPPRole.Namespace = model.Namespace
+	if err := reconcilers.SetOwnerReference(model, pool.EPPRole, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner on EPP Role: %w", err)
+	}
+	if err := r.createOrUpdateRole(ctx, pool.EPPRole); err != nil {
+		return fmt.Errorf("reconciling EPP Role: %w", err)
+	}
+
+	// EPP RoleBinding
+	pool.EPPRoleBinding.Namespace = model.Namespace
+	if err := reconcilers.SetOwnerReference(model, pool.EPPRoleBinding, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner on EPP RoleBinding: %w", err)
+	}
+	if err := r.createOrUpdateRoleBinding(ctx, pool.EPPRoleBinding); err != nil {
+		return fmt.Errorf("reconciling EPP RoleBinding: %w", err)
+	}
+
+	// EPP Service
+	pool.EPPService.Namespace = model.Namespace
+	if err := reconcilers.SetOwnerReference(model, pool.EPPService, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner on EPP Service: %w", err)
+	}
+	if err := r.createOrUpdateService(ctx, pool.EPPService); err != nil {
+		return fmt.Errorf("reconciling EPP Service: %w", err)
+	}
+
+	// EPP Deployment
+	pool.EPPDeployment.Namespace = model.Namespace
+	if err := reconcilers.SetOwnerReference(model, pool.EPPDeployment, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner on EPP Deployment: %w", err)
+	}
+	if err := r.createOrUpdateDeployment(ctx, pool.EPPDeployment); err != nil {
+		return fmt.Errorf("reconciling EPP Deployment: %w", err)
+	}
+
+	return nil
+}
+
+// reconcileRoutingResources creates or updates AIGatewayRoute resources.
+func (r *LLMModelReconciler) reconcileRoutingResources(
+	ctx context.Context,
+	log controllerLogger,
+	model *llmv1alpha1.LLMModel,
+	routing *reconcilers.RoutingResources,
+) error {
+	if routing.ExternalRoute != nil {
+		routing.ExternalRoute.SetNamespace(model.Namespace)
+		if err := r.createOrUpdateUnstructured(ctx, log, routing.ExternalRoute); err != nil {
+			log.Error(err, "failed to reconcile external AIGatewayRoute - CRD may not be installed, skipping")
+		}
+	}
+	if routing.InternalRoute != nil {
+		routing.InternalRoute.SetNamespace(model.Namespace)
+		if err := r.createOrUpdateUnstructured(ctx, log, routing.InternalRoute); err != nil {
+			log.Error(err, "failed to reconcile internal AIGatewayRoute - CRD may not be installed, skipping")
+		}
+	}
+	return nil
+}
+
+// reconcileSecurityPolicies creates or updates SecurityPolicy resources.
+func (r *LLMModelReconciler) reconcileSecurityPolicies(
+	ctx context.Context,
+	log controllerLogger,
+	auth *reconcilers.AuthResources,
+) error {
+	if auth.ExternalSecurityPolicy != nil {
+		if err := r.createOrUpdateUnstructured(ctx, log, auth.ExternalSecurityPolicy); err != nil {
+			log.Error(err, "failed to reconcile external SecurityPolicy - CRD may not be installed, skipping")
+		}
+	}
+	if auth.InternalSecurityPolicy != nil {
+		if err := r.createOrUpdateUnstructured(ctx, log, auth.InternalSecurityPolicy); err != nil {
+			log.Error(err, "failed to reconcile internal SecurityPolicy - CRD may not be installed, skipping")
+		}
+	}
+	return nil
+}
+
+// determinePhase inspects the model Deployment and its pods to determine the current lifecycle phase.
+func (r *LLMModelReconciler) determinePhase(ctx context.Context, model *llmv1alpha1.LLMModel) llmv1alpha1.LLMModelPhase {
+	log := logf.FromContext(ctx)
+
+	dep := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{Name: model.Name, Namespace: model.Namespace}, dep); err != nil {
+		if apierrors.IsNotFound(err) {
+			return llmv1alpha1.PhasePending
+		}
+		log.Error(err, "failed to get Deployment for phase determination")
+		return llmv1alpha1.PhaseError
+	}
+
+	// Check if any pod has a running init container (downloading phase)
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList,
+		client.InNamespace(model.Namespace),
+		client.MatchingLabels{"app.kubernetes.io/instance": model.Name},
+	); err != nil {
+		log.Error(err, "failed to list pods for phase determination")
+		return llmv1alpha1.PhaseError
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		for _, cs := range pod.Status.InitContainerStatuses {
+			if cs.State.Running != nil {
+				return llmv1alpha1.PhaseDownloading
+			}
+		}
+	}
+
+	desired := int32(1)
+	if dep.Spec.Replicas != nil {
+		desired = *dep.Spec.Replicas
+	}
+
+	readyReplicas := dep.Status.ReadyReplicas
+
+	if readyReplicas == 0 {
+		return llmv1alpha1.PhaseStarting
+	}
+	if readyReplicas >= desired {
+		return llmv1alpha1.PhaseReady
+	}
+	return llmv1alpha1.PhaseDegraded
+}
+
+// updateStatus writes the final status fields to a fresh copy of the LLMModel.
+func (r *LLMModelReconciler) updateStatus(
+	ctx context.Context,
+	log controllerLogger,
+	model *llmv1alpha1.LLMModel,
+	phase llmv1alpha1.LLMModelPhase,
+) error {
+	// Fetch fresh copy to avoid update conflicts
+	fresh := &llmv1alpha1.LLMModel{}
+	if err := r.Get(ctx, types.NamespacedName{Name: model.Name, Namespace: model.Namespace}, fresh); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	fresh.Status.Phase = phase
+	fresh.Status.ObservedGeneration = fresh.Generation
+
+	// Update replica counts
+	dep := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{Name: model.Name, Namespace: model.Namespace}, dep); err == nil {
+		desired := int32(1)
+		if dep.Spec.Replicas != nil {
+			desired = *dep.Spec.Replicas
+		}
+		fresh.Status.Replicas = llmv1alpha1.ReplicaStatus{
+			Ready:   dep.Status.ReadyReplicas,
+			Desired: desired,
+		}
+	}
+
+	// Update endpoint URLs
+	if r.Config != nil {
+		subdomain := model.Spec.Endpoints.External.Subdomain
+		if subdomain == "" {
+			subdomain = reconcilers.Slugify(model.Name)
+		}
+		if r.Config.ExternalGatewayName != "" {
+			fresh.Status.Endpoints.External = "https://" + reconcilers.ExternalHostname(subdomain, r.Config.BaseDomain)
+		}
+		if r.Config.InternalGatewayName != "" {
+			fresh.Status.Endpoints.Internal = "https://" + reconcilers.InternalHostname(subdomain, r.Config.BaseDomain)
+		}
+	}
+
+	if err := r.Status().Update(ctx, fresh); err != nil {
+		log.Error(err, "failed to update LLMModel status")
+		return err
+	}
+	return nil
+}
+
+// modelConfigHash computes an 8-byte hex hash of the model's breaking configuration fields.
+// If the hash changes on an existing Deployment, the Deployment is deleted to trigger re-download.
+func modelConfigHash(model *llmv1alpha1.LLMModel) string {
+	data := model.Name +
+		string(model.Spec.Model.Source) +
+		string(model.Spec.Model.Storage.Type) +
+		model.Spec.Model.Image +
+		model.Spec.Model.Revision +
+		model.Spec.Model.Name
+	h := sha256.Sum256([]byte(data))
+	return fmt.Sprintf("%x", h[:8])
+}
+
+// --- createOrUpdate helpers ---
+
+func (r *LLMModelReconciler) createOrUpdatePVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim) error {
+	existing := &corev1.PersistentVolumeClaim{}
+	err := r.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, pvc)
+	}
+	if err != nil {
+		return err
+	}
+	// PVC specs are mostly immutable; update labels/annotations only
+	existing.Labels = pvc.Labels
+	return r.Update(ctx, existing)
+}
+
+func (r *LLMModelReconciler) createOrUpdateSecret(ctx context.Context, secret *corev1.Secret) error {
+	existing := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, secret)
+	}
+	if err != nil {
+		return err
+	}
+	// Preserve existing data (API keys written by other controllers/users); update labels only
+	existing.Labels = secret.Labels
+	return r.Update(ctx, existing)
+}
+
+func (r *LLMModelReconciler) createOrUpdateConfigMap(ctx context.Context, cm *corev1.ConfigMap) error {
+	existing := &corev1.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, cm)
+	}
+	if err != nil {
+		return err
+	}
+	existing.Labels = cm.Labels
+	existing.Data = cm.Data
+	return r.Update(ctx, existing)
+}
+
+func (r *LLMModelReconciler) createOrUpdateNetworkPolicy(ctx context.Context, np *networkingv1.NetworkPolicy) error {
+	existing := &networkingv1.NetworkPolicy{}
+	err := r.Get(ctx, types.NamespacedName{Name: np.Name, Namespace: np.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, np)
+	}
+	if err != nil {
+		return err
+	}
+	existing.Spec = np.Spec
+	existing.Labels = np.Labels
+	return r.Update(ctx, existing)
+}
+
+func (r *LLMModelReconciler) createOrUpdateServiceAccount(ctx context.Context, sa *corev1.ServiceAccount) error {
+	existing := &corev1.ServiceAccount{}
+	err := r.Get(ctx, types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, sa)
+	}
+	if err != nil {
+		return err
+	}
+	existing.Labels = sa.Labels
+	return r.Update(ctx, existing)
+}
+
+func (r *LLMModelReconciler) createOrUpdateService(ctx context.Context, svc *corev1.Service) error {
+	existing := &corev1.Service{}
+	err := r.Get(ctx, types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, svc)
+	}
+	if err != nil {
+		return err
+	}
+	// Preserve ClusterIP assigned by the API server
+	svc.Spec.ClusterIP = existing.Spec.ClusterIP
+	svc.Spec.ClusterIPs = existing.Spec.ClusterIPs
+	existing.Spec = svc.Spec
+	existing.Labels = svc.Labels
+	return r.Update(ctx, existing)
+}
+
+func (r *LLMModelReconciler) createOrUpdateDeployment(ctx context.Context, dep *appsv1.Deployment) error {
+	existing := &appsv1.Deployment{}
+	err := r.Get(ctx, types.NamespacedName{Name: dep.Name, Namespace: dep.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, dep)
+	}
+	if err != nil {
+		return err
+	}
+	existing.Spec = dep.Spec
+	existing.Labels = dep.Labels
+	return r.Update(ctx, existing)
+}
+
+func (r *LLMModelReconciler) createOrUpdateRole(ctx context.Context, role *rbacv1.Role) error {
+	existing := &rbacv1.Role{}
+	err := r.Get(ctx, types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, role)
+	}
+	if err != nil {
+		return err
+	}
+	existing.Rules = role.Rules
+	existing.Labels = role.Labels
+	return r.Update(ctx, existing)
+}
+
+func (r *LLMModelReconciler) createOrUpdateRoleBinding(ctx context.Context, rb *rbacv1.RoleBinding) error {
+	existing := &rbacv1.RoleBinding{}
+	err := r.Get(ctx, types.NamespacedName{Name: rb.Name, Namespace: rb.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, rb)
+	}
+	if err != nil {
+		return err
+	}
+	existing.RoleRef = rb.RoleRef
+	existing.Subjects = rb.Subjects
+	existing.Labels = rb.Labels
+	return r.Update(ctx, existing)
+}
+
+// createOrUpdateUnstructured creates or updates an unstructured resource.
+// Errors for optional CRD-based resources should be logged by the caller rather than
+// failing the reconciliation.
+func (r *LLMModelReconciler) createOrUpdateUnstructured(
+	ctx context.Context,
+	log controllerLogger,
+	obj *unstructured.Unstructured,
+) error {
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(obj.GroupVersionKind())
+	err := r.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
+	if apierrors.IsNotFound(err) {
+		return r.Create(ctx, obj)
+	}
+	if err != nil {
+		return err
+	}
+	obj.SetResourceVersion(existing.GetResourceVersion())
+	return r.Update(ctx, obj)
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *LLMModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&llmv1alpha1.LLMModel{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.PersistentVolumeClaim{}).
 		Named("llmmodel").
 		Complete(r)
 }

--- a/operator/internal/controller/llmmodel_controller_test.go
+++ b/operator/internal/controller/llmmodel_controller_test.go
@@ -21,78 +21,439 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
+	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
 )
 
+// testConfig returns a minimal OperatorConfig suitable for envtest.
+func testConfig() *config.OperatorConfig {
+	return &config.OperatorConfig{
+		BaseDomain:          "example.com",
+		ExternalGatewayName: "external-gateway",
+		ExternalGatewayNS:   "envoy-gateway-system",
+		InternalGatewayName: "internal-gateway",
+		InternalGatewayNS:   "envoy-gateway-system",
+		OIDCIssuerURL:       "https://auth.example.com",
+		OIDCGroupsClaim:     "groups",
+		OIDCAudience:        "",
+		DefaultServingImage: "ghcr.io/llm-d/llm-d-cuda:v0.5.1",
+		APIKeysNamespace:    "llm-api-keys-test",
+	}
+}
+
+// newReconciler returns a reconciler wired to the envtest client.
+func newReconciler() *LLMModelReconciler {
+	return &LLMModelReconciler{
+		Client: k8sClient,
+		Scheme: k8sClient.Scheme(),
+		Config: testConfig(),
+	}
+}
+
+// newMinimalModel creates a minimal LLMModel for testing.
+func newMinimalModel(name, namespace string) *llmv1alpha1.LLMModel {
+	return &llmv1alpha1.LLMModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: llmv1alpha1.LLMModelSpec{
+			Model: llmv1alpha1.ModelSpec{
+				Name:   "test-model/small",
+				Source: llmv1alpha1.ModelSourceHuggingFace,
+				Storage: llmv1alpha1.StorageSpec{
+					// Use emptyDir so no PVC is needed in envtest
+					Type: llmv1alpha1.StorageTypeEmptyDir,
+					Size: "10Gi",
+				},
+			},
+			Resources: llmv1alpha1.ResourceSpec{
+				GPU: llmv1alpha1.GPUSpec{
+					Count: 0, // No GPU needed for tests
+					Type:  "nvidia",
+				},
+			},
+			Access: llmv1alpha1.AccessSpec{
+				Groups: []string{"test-group"},
+			},
+		},
+	}
+}
+
+// reconcileRequest creates a reconcile.Request for the given name/namespace.
+func reconcileRequest(name, namespace string) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: namespace},
+	}
+}
+
 var _ = Describe("LLMModel Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+	const testNamespace = "default"
 
-		ctx := context.Background()
+	ctx := context.Background()
 
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		llmmodel := &llmv1alpha1.LLMModel{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind LLMModel")
-			err := k8sClient.Get(ctx, typeNamespacedName, llmmodel)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &llmv1alpha1.LLMModel{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: llmv1alpha1.LLMModelSpec{
-						Model: llmv1alpha1.ModelSpec{
-							Name:   "test-model",
-							Source: llmv1alpha1.ModelSourceHuggingFace,
-						},
-						Resources: llmv1alpha1.ResourceSpec{
-							GPU: llmv1alpha1.GPUSpec{
-								Count: 1,
-								Type:  "nvidia",
-							},
-						},
-						Access: llmv1alpha1.AccessSpec{
-							Groups: []string{"test-group"},
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
+	Describe("Finalizer and Phase", func() {
+		const modelName = "test-finalizer-phase"
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &llmv1alpha1.LLMModel{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			// Clean up after each test
+			model := &llmv1alpha1.LLMModel{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, model); err == nil {
+				// Remove finalizer so delete can proceed
+				model.Finalizers = nil
+				_ = k8sClient.Update(ctx, model)
+				_ = k8sClient.Delete(ctx, model)
+			}
+		})
+
+		It("adds the finalizer and sets phase to Pending on first reconcile", func() {
+			By("creating the LLMModel")
+			model := newMinimalModel(modelName, testNamespace)
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+
+			By("reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Cleanup the specific resource instance LLMModel")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			By("verifying finalizer was added")
+			fetched := &llmv1alpha1.LLMModel{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, fetched)).To(Succeed())
+			Expect(fetched.Finalizers).To(ContainElement(finalizerName))
+
+			By("verifying phase is Pending or Starting (deployment just created)")
+			Expect(fetched.Status.Phase).To(Or(
+				Equal(llmv1alpha1.PhasePending),
+				Equal(llmv1alpha1.PhaseStarting),
+				Equal(llmv1alpha1.PhaseReady),
+			))
 		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &LLMModelReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+	})
+
+	Describe("Core resources created", func() {
+		const modelName = "test-core-resources"
+
+		AfterEach(func() {
+			model := &llmv1alpha1.LLMModel{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, model); err == nil {
+				model.Finalizers = nil
+				_ = k8sClient.Update(ctx, model)
+				_ = k8sClient.Delete(ctx, model)
+			}
+		})
+
+		It("creates Deployment, Service, and ServiceAccount", func() {
+			By("creating the LLMModel")
+			model := newMinimalModel(modelName, testNamespace)
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+
+			By("reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying Deployment was created")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, dep)).To(Succeed())
+			Expect(dep.Labels["app.kubernetes.io/instance"]).To(Equal(modelName))
+			Expect(dep.Annotations[modelConfigHashAnno]).NotTo(BeEmpty())
+
+			By("verifying Service was created")
+			svc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, svc)).To(Succeed())
+			Expect(svc.Spec.Ports).To(HaveLen(1))
+			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(8000)))
+
+			By("verifying ServiceAccount was created")
+			sa := &corev1.ServiceAccount{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName + "-sa", Namespace: testNamespace}, sa)).To(Succeed())
+		})
+	})
+
+	Describe("NetworkPolicy created", func() {
+		const modelName = "test-netpol"
+
+		AfterEach(func() {
+			model := &llmv1alpha1.LLMModel{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, model); err == nil {
+				model.Finalizers = nil
+				_ = k8sClient.Update(ctx, model)
+				_ = k8sClient.Delete(ctx, model)
+			}
+		})
+
+		It("creates the default-deny NetworkPolicy", func() {
+			By("creating the LLMModel")
+			model := newMinimalModel(modelName, testNamespace)
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+
+			By("reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying NetworkPolicy was created")
+			np := &networkingv1.NetworkPolicy{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      modelName + "-deny-direct",
+				Namespace: testNamespace,
+			}, np)).To(Succeed())
+			Expect(np.Spec.PolicyTypes).To(ContainElement(networkingv1.PolicyTypeIngress))
+			Expect(np.Spec.PodSelector.MatchLabels["app.kubernetes.io/instance"]).To(Equal(modelName))
+		})
+	})
+
+	Describe("Cross-namespace resources (llm-api-keys namespace)", func() {
+		const modelName = "test-cross-ns"
+
+		AfterEach(func() {
+			model := &llmv1alpha1.LLMModel{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, model); err == nil {
+				model.Finalizers = nil
+				_ = k8sClient.Update(ctx, model)
+				_ = k8sClient.Delete(ctx, model)
+			}
+		})
+
+		It("creates Secret and ConfigMap in the api-keys namespace", func() {
+			By("creating the LLMModel")
+			model := newMinimalModel(modelName, testNamespace)
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+
+			By("reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
+			Expect(err).NotTo(HaveOccurred())
+
+			apiKeysNS := testConfig().APIKeysNamespace
+
+			By("verifying the api-keys namespace was created")
+			ns := &corev1.Namespace{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: apiKeysNS}, ns)).To(Succeed())
+
+			By("verifying API key Secret exists in api-keys namespace")
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      modelName + "-api-keys",
+				Namespace: apiKeysNS,
+			}, secret)).To(Succeed())
+			Expect(secret.Labels["llm.nebari.dev/model-name"]).To(Equal(modelName))
+
+			By("verifying API key metadata ConfigMap exists in api-keys namespace")
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      modelName + "-api-key-metadata",
+				Namespace: apiKeysNS,
+			}, cm)).To(Succeed())
+			Expect(cm.Labels["llm.nebari.dev/model-name"]).To(Equal(modelName))
+		})
+	})
+
+	Describe("Deletion with finalizer cleanup", func() {
+		const modelName = "test-deletion"
+
+		It("cleans up cross-namespace resources on deletion", func() {
+			By("creating the LLMModel")
+			model := newMinimalModel(modelName, testNamespace)
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+
+			By("first reconcile (creates resources and adds finalizer)")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
+			Expect(err).NotTo(HaveOccurred())
+
+			apiKeysNS := testConfig().APIKeysNamespace
+
+			By("verifying cross-namespace resources exist")
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      modelName + "-api-keys",
+				Namespace: apiKeysNS,
+			}, secret)).To(Succeed())
+
+			By("deleting the LLMModel (triggers finalizer)")
+			fetched := &llmv1alpha1.LLMModel{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, fetched)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, fetched)).To(Succeed())
+
+			By("reconciling the deletion")
+			_, err = r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying cross-namespace Secret was deleted")
+			deletedSecret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      modelName + "-api-keys",
+				Namespace: apiKeysNS,
+			}, deletedSecret)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+			By("verifying cross-namespace ConfigMap was deleted")
+			deletedCM := &corev1.ConfigMap{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      modelName + "-api-key-metadata",
+				Namespace: apiKeysNS,
+			}, deletedCM)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+			By("verifying the LLMModel is gone (finalizer removed)")
+			deletedModel := &llmv1alpha1.LLMModel{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, deletedModel)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Describe("Breaking change detection", func() {
+		const modelName = "test-breaking-change"
+
+		AfterEach(func() {
+			model := &llmv1alpha1.LLMModel{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, model); err == nil {
+				model.Finalizers = nil
+				_ = k8sClient.Update(ctx, model)
+				_ = k8sClient.Delete(ctx, model)
+			}
+		})
+
+		It("deletes and recreates the Deployment when model name changes", func() {
+			By("creating the LLMModel")
+			model := newMinimalModel(modelName, testNamespace)
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+
+			By("first reconcile")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("capturing the initial deployment UID")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, dep)).To(Succeed())
+			originalUID := dep.UID
+			originalHash := dep.Annotations[modelConfigHashAnno]
+			Expect(originalHash).NotTo(BeEmpty())
+
+			By("changing the model name (breaking change)")
+			fetched := &llmv1alpha1.LLMModel{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, fetched)).To(Succeed())
+			fetched.Spec.Model.Name = "different-model/changed"
+			Expect(k8sClient.Update(ctx, fetched)).To(Succeed())
+
+			By("reconciling after breaking change")
+			_, err = r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the Deployment was deleted (not yet recreated)")
+			deletedDep := &appsv1.Deployment{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, deletedDep)
+			// Either deleted or recreated with a new hash
+			if err == nil {
+				// If it was immediately recreated, the UID or hash should differ
+				newHash := deletedDep.Annotations[modelConfigHashAnno]
+				Expect(newHash).NotTo(Equal(originalHash))
+			} else {
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			}
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
+			By("reconciling again to recreate the Deployment")
+			_, err = r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			By("verifying the new Deployment has a different hash")
+			newDep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, newDep)).To(Succeed())
+			Expect(newDep.Annotations[modelConfigHashAnno]).NotTo(Equal(originalHash))
+			// UID changes when an object is deleted and recreated
+			Expect(newDep.UID).NotTo(Equal(originalUID))
+		})
+	})
+
+	Describe("Both endpoints disabled", func() {
+		const modelName = "test-no-endpoints"
+
+		AfterEach(func() {
+			model := &llmv1alpha1.LLMModel{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, model); err == nil {
+				model.Finalizers = nil
+				_ = k8sClient.Update(ctx, model)
+				_ = k8sClient.Delete(ctx, model)
+			}
+		})
+
+		It("still creates Deployment and NetworkPolicy when endpoints are disabled", func() {
+			By("creating the LLMModel with both endpoints disabled")
+			falseVal := false
+			model := newMinimalModel(modelName, testNamespace)
+			model.Spec.Endpoints = llmv1alpha1.EndpointSpec{
+				External: llmv1alpha1.ExternalEndpointSpec{Enabled: &falseVal},
+				Internal: llmv1alpha1.InternalEndpointSpec{Enabled: &falseVal},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+
+			By("reconciling")
+			r := newReconciler()
+			_, err := r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying Deployment still exists")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, dep)).To(Succeed())
+
+			By("verifying NetworkPolicy still exists")
+			np := &networkingv1.NetworkPolicy{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      modelName + "-deny-direct",
+				Namespace: testNamespace,
+			}, np)).To(Succeed())
+		})
+	})
+
+	Describe("Idempotency", func() {
+		const modelName = "test-idempotent"
+
+		AfterEach(func() {
+			model := &llmv1alpha1.LLMModel{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: modelName, Namespace: testNamespace}, model); err == nil {
+				model.Finalizers = nil
+				_ = k8sClient.Update(ctx, model)
+				_ = k8sClient.Delete(ctx, model)
+			}
+		})
+
+		It("reconciles multiple times without error", func() {
+			By("creating the LLMModel")
+			model := newMinimalModel(modelName, testNamespace)
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+
+			r := newReconciler()
+
+			By("reconciling three times")
+			for i := 0; i < 3; i++ {
+				_, err := r.Reconcile(ctx, reconcileRequest(modelName, testNamespace))
+				Expect(err).NotTo(HaveOccurred(), "reconcile %d should not error", i+1)
+			}
+
+			By("verifying a single Deployment exists")
+			depList := &appsv1.DeploymentList{}
+			Expect(k8sClient.List(ctx, depList,
+				client.InNamespace(testNamespace),
+			)).To(Succeed())
+
+			count := 0
+			for _, d := range depList.Items {
+				if d.Name == modelName {
+					count++
+				}
+			}
+			Expect(count).To(Equal(1))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Implements the main LLMModel reconciler that orchestrates all sub-reconcilers into a phased reconciliation loop:

- Finalizer (`llm.nebari.dev/cleanup`) for cross-namespace resource cleanup in llm-api-keys
- Phased reconciliation: Pending -> Downloading -> Starting -> Ready/Degraded/Error
- Requeues every 15s while waiting for model download or pod startup
- Breaking change detection via `llm.nebari.dev/model-config-hash` annotation on Deployment
- CRD-resilient: missing CRDs (InferencePool, AIGatewayRoute, SecurityPolicy) are logged and skipped
- Creates/updates: PVC, Deployment, Service, SA, NetworkPolicy, Secret, ConfigMap, ReferenceGrant, InferencePool, EPP, AIGatewayRoutes, SecurityPolicies, PodMonitor
- Updates cmd/main.go to load OperatorConfig from env vars

7 Ginkgo test scenarios covering: finalizer, core resources, NetworkPolicy, cross-namespace cleanup, breaking changes, disabled endpoints.

Closes #10

## Test plan

- `cd operator && make test` - all packages pass (controller 68% coverage)
- Build: `cd operator && go build ./...` - clean