### PR TITLE
Implement API key CRUD via K8s Secrets and ConfigMaps

### DIFF
--- a/key-manager/internal/secrets/manager.go
+++ b/key-manager/internal/secrets/manager.go
@@ -1,0 +1,266 @@
+package secrets
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// KeyInfo contains metadata about an API key (never the key value itself).
+type KeyInfo struct {
+	ClientID    string    `json:"clientId"`
+	Creator     string    `json:"creator"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+	ModelName   string    `json:"modelName"`
+	Namespace   string    `json:"namespace"`
+}
+
+// CreateKeyResult is returned when a new key is created.
+type CreateKeyResult struct {
+	ClientID string // e.g., "user-chuck-1"
+	APIKey   string // e.g., "sk-abc123..." - only returned once at creation time
+}
+
+// Manager handles API key CRUD via K8s Secrets and ConfigMaps.
+type Manager struct {
+	client    client.Client
+	namespace string // the llm-api-keys namespace
+}
+
+// NewManager creates a new Manager.
+func NewManager(c client.Client, namespace string) *Manager {
+	return &Manager{client: c, namespace: namespace}
+}
+
+// secretName returns the name of the Secret for a model.
+func secretName(modelName string) string {
+	return modelName + "-api-keys"
+}
+
+// configMapName returns the name of the ConfigMap for a model.
+func configMapName(modelName string) string {
+	return modelName + "-api-key-metadata"
+}
+
+// generateAPIKey generates a new API key with sk- prefix and 32 random base64url characters.
+func generateAPIKey() (string, error) {
+	// 24 random bytes => 32 base64url characters (no padding)
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating random bytes: %w", err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(b)
+	return "sk-" + encoded, nil
+}
+
+// getSecret fetches the Secret for a model, returning a descriptive error if not found.
+func (m *Manager) getSecret(ctx context.Context, modelName string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Namespace: m.namespace, Name: secretName(modelName)}
+	if err := m.client.Get(ctx, key, secret); err != nil {
+		return nil, fmt.Errorf("API key secret not found for model %s - has the operator created it?: %w", modelName, err)
+	}
+	return secret, nil
+}
+
+// getConfigMap fetches the ConfigMap for a model, returning a descriptive error if not found.
+func (m *Manager) getConfigMap(ctx context.Context, modelName string) (*corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Namespace: m.namespace, Name: configMapName(modelName)}
+	if err := m.client.Get(ctx, key, cm); err != nil {
+		return nil, fmt.Errorf("API key metadata ConfigMap not found for model %s - has the operator created it?: %w", modelName, err)
+	}
+	return cm, nil
+}
+
+// CreateKey generates a new API key for a model, writes it to the Secret,
+// and stores metadata in the ConfigMap. Returns the key (only time it's shown).
+func (m *Manager) CreateKey(ctx context.Context, modelName, username, description string) (*CreateKeyResult, error) {
+	const maxRetries = 3
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		result, err := m.createKeyOnce(ctx, modelName, username, description)
+		if err == nil {
+			return result, nil
+		}
+		// On conflict, retry; on other errors, return immediately.
+		if !isConflict(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("creating key for model %s: too many conflicts", modelName)
+}
+
+func (m *Manager) createKeyOnce(ctx context.Context, modelName, username, description string) (*CreateKeyResult, error) {
+	secret, err := m.getSecret(ctx, modelName)
+	if err != nil {
+		return nil, err
+	}
+	cm, err := m.getConfigMap(ctx, modelName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Count existing keys for this user to determine the sequence number.
+	userPrefix := "user-" + username + "-"
+	count := 0
+	for k := range secret.Data {
+		if strings.HasPrefix(k, userPrefix) {
+			count++
+		}
+	}
+	sequence := count + 1
+	clientID := fmt.Sprintf("user-%s-%d", username, sequence)
+
+	apiKey, err := generateAPIKey()
+	if err != nil {
+		return nil, fmt.Errorf("generating API key: %w", err)
+	}
+
+	// Write the key to the Secret.
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	secret.Data[clientID] = []byte(apiKey)
+	if err := m.client.Update(ctx, secret); err != nil {
+		return nil, fmt.Errorf("updating Secret for model %s: %w", modelName, err)
+	}
+
+	// Write metadata to the ConfigMap.
+	info := KeyInfo{
+		ClientID:    clientID,
+		Creator:     username,
+		Description: description,
+		CreatedAt:   time.Now().UTC().Truncate(time.Second),
+		ModelName:   modelName,
+		Namespace:   m.namespace,
+	}
+	infoJSON, err := json.Marshal(info)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling key metadata: %w", err)
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[clientID] = string(infoJSON)
+	if err := m.client.Update(ctx, cm); err != nil {
+		return nil, fmt.Errorf("updating ConfigMap for model %s: %w", modelName, err)
+	}
+
+	return &CreateKeyResult{
+		ClientID: clientID,
+		APIKey:   apiKey,
+	}, nil
+}
+
+// ListKeys returns metadata for all keys belonging to a model.
+func (m *Manager) ListKeys(ctx context.Context, modelName string) ([]KeyInfo, error) {
+	cm, err := m.getConfigMap(ctx, modelName)
+	if err != nil {
+		return nil, err
+	}
+	return parseConfigMapKeys(cm), nil
+}
+
+// ListKeysForUser returns metadata for keys created by a specific user across all models.
+func (m *Manager) ListKeysForUser(ctx context.Context, username string) ([]KeyInfo, error) {
+	// List all ConfigMaps in the namespace and filter by label/name to find API key metadata ConfigMaps.
+	allCMs := &corev1.ConfigMapList{}
+	if err := m.client.List(ctx, allCMs, client.InNamespace(m.namespace)); err != nil {
+		return nil, fmt.Errorf("listing ConfigMaps: %w", err)
+	}
+
+	var result []KeyInfo
+	for i := range allCMs.Items {
+		cm := &allCMs.Items[i]
+		// Only process ConfigMaps that are API key metadata ConfigMaps (have the label).
+		if _, ok := cm.Labels["llm.nebari.dev/model-name"]; !ok {
+			continue
+		}
+		// Only process ConfigMaps with the -api-key-metadata suffix.
+		if !strings.HasSuffix(cm.Name, "-api-key-metadata") {
+			continue
+		}
+		for _, info := range parseConfigMapKeys(cm) {
+			if info.Creator == username {
+				result = append(result, info)
+			}
+		}
+	}
+	return result, nil
+}
+
+// RevokeKey removes a key from the Secret and its metadata from the ConfigMap.
+func (m *Manager) RevokeKey(ctx context.Context, modelName, clientID string) error {
+	const maxRetries = 3
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		err := m.revokeKeyOnce(ctx, modelName, clientID)
+		if err == nil {
+			return nil
+		}
+		if !isConflict(err) {
+			return err
+		}
+	}
+	return fmt.Errorf("revoking key %s for model %s: too many conflicts", clientID, modelName)
+}
+
+func (m *Manager) revokeKeyOnce(ctx context.Context, modelName, clientID string) error {
+	secret, err := m.getSecret(ctx, modelName)
+	if err != nil {
+		return err
+	}
+	cm, err := m.getConfigMap(ctx, modelName)
+	if err != nil {
+		return err
+	}
+
+	// Check the key exists before attempting removal.
+	if _, ok := secret.Data[clientID]; !ok {
+		return fmt.Errorf("key %q not found for model %s", clientID, modelName)
+	}
+
+	delete(secret.Data, clientID)
+	if err := m.client.Update(ctx, secret); err != nil {
+		return fmt.Errorf("updating Secret for model %s: %w", modelName, err)
+	}
+
+	delete(cm.Data, clientID)
+	if err := m.client.Update(ctx, cm); err != nil {
+		return fmt.Errorf("updating ConfigMap for model %s: %w", modelName, err)
+	}
+
+	return nil
+}
+
+// parseConfigMapKeys parses all KeyInfo entries from a ConfigMap's data map.
+func parseConfigMapKeys(cm *corev1.ConfigMap) []KeyInfo {
+	var result []KeyInfo
+	for _, v := range cm.Data {
+		var info KeyInfo
+		if err := json.Unmarshal([]byte(v), &info); err != nil {
+			continue
+		}
+		result = append(result, info)
+	}
+	return result
+}
+
+// isConflict returns true if the error is a Kubernetes conflict (409).
+func isConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "conflict") ||
+		strings.Contains(err.Error(), "409")
+}

--- a/key-manager/internal/secrets/manager_test.go
+++ b/key-manager/internal/secrets/manager_test.go
@@ -1,0 +1,450 @@
+package secrets_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/secrets"
+)
+
+const testNamespace = "llm-api-keys"
+
+func buildScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := corev1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return s
+}
+
+// makeSecret creates a pre-existing empty Secret as the operator would have created it.
+func makeSecret(modelName, namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      modelName + "-api-keys",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"llm.nebari.dev/model-name": modelName,
+			},
+		},
+		Data: map[string][]byte{},
+	}
+}
+
+// makeConfigMap creates a pre-existing empty ConfigMap as the operator would have created it.
+func makeConfigMap(modelName, namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      modelName + "-api-key-metadata",
+			Namespace: namespace,
+			Labels: map[string]string{
+				"llm.nebari.dev/model-name": modelName,
+			},
+		},
+		Data: map[string]string{},
+	}
+}
+
+func TestCreateKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		modelName   string
+		username    string
+		description string
+	}{
+		{
+			name:        "generates sk- prefixed key and writes to Secret and ConfigMap",
+			modelName:   "my-model",
+			username:    "chuck",
+			description: "test key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := buildScheme(t)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(
+					makeSecret(tc.modelName, testNamespace),
+					makeConfigMap(tc.modelName, testNamespace),
+				).
+				Build()
+
+			mgr := secrets.NewManager(fakeClient, testNamespace)
+			result, err := mgr.CreateKey(context.Background(), tc.modelName, tc.username, tc.description)
+			if err != nil {
+				t.Fatalf("CreateKey error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if !strings.HasPrefix(result.APIKey, "sk-") {
+				t.Errorf("expected APIKey with prefix sk-, got %q", result.APIKey)
+			}
+			// Verify key length: "sk-" + 32 base64url chars = 35 chars
+			if len(result.APIKey) != 35 {
+				t.Errorf("expected APIKey length 35, got %d: %q", len(result.APIKey), result.APIKey)
+			}
+
+			// Verify key was written to the Secret
+			secret := &corev1.Secret{}
+			secretKey := types.NamespacedName{Namespace: testNamespace, Name: tc.modelName + "-api-keys"}
+			if err := fakeClient.Get(context.Background(), secretKey, secret); err != nil {
+				t.Fatalf("Get Secret: %v", err)
+			}
+			if _, ok := secret.Data[result.ClientID]; !ok {
+				t.Errorf("expected clientID %q in Secret data", result.ClientID)
+			}
+			if string(secret.Data[result.ClientID]) != result.APIKey {
+				t.Errorf("expected Secret data[%q]=%q, got %q", result.ClientID, result.APIKey, string(secret.Data[result.ClientID]))
+			}
+
+			// Verify metadata was written to ConfigMap
+			cm := &corev1.ConfigMap{}
+			cmKey := types.NamespacedName{Namespace: testNamespace, Name: tc.modelName + "-api-key-metadata"}
+			if err := fakeClient.Get(context.Background(), cmKey, cm); err != nil {
+				t.Fatalf("Get ConfigMap: %v", err)
+			}
+			if _, ok := cm.Data[result.ClientID]; !ok {
+				t.Errorf("expected clientID %q in ConfigMap data", result.ClientID)
+			}
+		})
+	}
+}
+
+func TestCreateKey_ClientIDFormat(t *testing.T) {
+	tests := []struct {
+		name         string
+		username     string
+		existingKeys []string // clientIDs already in the secret for this user
+		wantClientID string
+	}{
+		{
+			name:         "first key for user is -1",
+			username:     "chuck",
+			existingKeys: []string{},
+			wantClientID: "user-chuck-1",
+		},
+		{
+			name:         "second key for user is -2",
+			username:     "chuck",
+			existingKeys: []string{"user-chuck-1"},
+			wantClientID: "user-chuck-2",
+		},
+		{
+			name:         "third key for user is -3",
+			username:     "chuck",
+			existingKeys: []string{"user-chuck-1", "user-chuck-2"},
+			wantClientID: "user-chuck-3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := buildScheme(t)
+
+			// Build pre-existing secret data with existing keys
+			secretData := map[string][]byte{}
+			for _, k := range tc.existingKeys {
+				secretData[k] = []byte("sk-existingkey00000000000000000000")
+			}
+			cmData := map[string]string{}
+			for _, k := range tc.existingKeys {
+				cmData[k] = `{"clientId":"` + k + `","creator":"chuck","description":"","createdAt":"2024-01-01T00:00:00Z","modelName":"my-model","namespace":"llm-api-keys"}`
+			}
+
+			secret := makeSecret("my-model", testNamespace)
+			secret.Data = secretData
+			cm := makeConfigMap("my-model", testNamespace)
+			cm.Data = cmData
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(secret, cm).
+				Build()
+
+			mgr := secrets.NewManager(fakeClient, testNamespace)
+			result, err := mgr.CreateKey(context.Background(), "my-model", tc.username, "test")
+			if err != nil {
+				t.Fatalf("CreateKey error: %v", err)
+			}
+			if result.ClientID != tc.wantClientID {
+				t.Errorf("expected ClientID %q, got %q", tc.wantClientID, result.ClientID)
+			}
+		})
+	}
+}
+
+func TestCreateKey_SecretNotFound(t *testing.T) {
+	scheme := buildScheme(t)
+	// Only create ConfigMap, not Secret - simulates operator not having created the secret yet
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(makeConfigMap("missing-model", testNamespace)).
+		Build()
+
+	mgr := secrets.NewManager(fakeClient, testNamespace)
+	_, err := mgr.CreateKey(context.Background(), "missing-model", "chuck", "test")
+	if err == nil {
+		t.Fatal("expected error when Secret does not exist, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing-model") {
+		t.Errorf("expected error to mention model name, got: %v", err)
+	}
+}
+
+func TestListKeys(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelName string
+		cmData    map[string]string
+		wantCount int
+	}{
+		{
+			name:      "returns metadata for all keys of a model",
+			modelName: "my-model",
+			cmData: map[string]string{
+				"user-alice-1": `{"clientId":"user-alice-1","creator":"alice","description":"alice key","createdAt":"2024-01-01T00:00:00Z","modelName":"my-model","namespace":"llm-api-keys"}`,
+				"user-bob-1":   `{"clientId":"user-bob-1","creator":"bob","description":"bob key","createdAt":"2024-01-02T00:00:00Z","modelName":"my-model","namespace":"llm-api-keys"}`,
+			},
+			wantCount: 2,
+		},
+		{
+			name:      "returns empty list when ConfigMap has no entries",
+			modelName: "empty-model",
+			cmData:    map[string]string{},
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := buildScheme(t)
+
+			cm := makeConfigMap(tc.modelName, testNamespace)
+			cm.Data = tc.cmData
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(
+					makeSecret(tc.modelName, testNamespace),
+					cm,
+				).
+				Build()
+
+			mgr := secrets.NewManager(fakeClient, testNamespace)
+			keys, err := mgr.ListKeys(context.Background(), tc.modelName)
+			if err != nil {
+				t.Fatalf("ListKeys error: %v", err)
+			}
+			if len(keys) != tc.wantCount {
+				t.Errorf("expected %d keys, got %d", tc.wantCount, len(keys))
+			}
+		})
+	}
+}
+
+func TestListKeysForUser(t *testing.T) {
+	tests := []struct {
+		name      string
+		models    []string
+		cmDatas   map[string]map[string]string // modelName -> cmData
+		username  string
+		wantCount int
+	}{
+		{
+			name:   "returns keys created by user across multiple models",
+			models: []string{"model-a", "model-b"},
+			cmDatas: map[string]map[string]string{
+				"model-a": {
+					"user-chuck-1": `{"clientId":"user-chuck-1","creator":"chuck","description":"","createdAt":"2024-01-01T00:00:00Z","modelName":"model-a","namespace":"llm-api-keys"}`,
+					"user-alice-1": `{"clientId":"user-alice-1","creator":"alice","description":"","createdAt":"2024-01-01T00:00:00Z","modelName":"model-a","namespace":"llm-api-keys"}`,
+				},
+				"model-b": {
+					"user-chuck-1": `{"clientId":"user-chuck-1","creator":"chuck","description":"","createdAt":"2024-01-02T00:00:00Z","modelName":"model-b","namespace":"llm-api-keys"}`,
+				},
+			},
+			username:  "chuck",
+			wantCount: 2,
+		},
+		{
+			name:   "user with no keys returns empty list",
+			models: []string{"model-a"},
+			cmDatas: map[string]map[string]string{
+				"model-a": {
+					"user-alice-1": `{"clientId":"user-alice-1","creator":"alice","description":"","createdAt":"2024-01-01T00:00:00Z","modelName":"model-a","namespace":"llm-api-keys"}`,
+				},
+			},
+			username:  "chuck",
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := buildScheme(t)
+
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			for _, modelName := range tc.models {
+				cm := makeConfigMap(modelName, testNamespace)
+				if data, ok := tc.cmDatas[modelName]; ok {
+					cm.Data = data
+				}
+				builder = builder.WithObjects(makeSecret(modelName, testNamespace), cm)
+			}
+			fakeClient := builder.Build()
+
+			mgr := secrets.NewManager(fakeClient, testNamespace)
+			keys, err := mgr.ListKeysForUser(context.Background(), tc.username)
+			if err != nil {
+				t.Fatalf("ListKeysForUser error: %v", err)
+			}
+			if len(keys) != tc.wantCount {
+				t.Errorf("expected %d keys for user %q, got %d", tc.wantCount, tc.username, len(keys))
+			}
+		})
+	}
+}
+
+func TestRevokeKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		modelName  string
+		clientID   string
+		secretData map[string][]byte
+		cmData     map[string]string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:      "removes key from Secret and ConfigMap",
+			modelName: "my-model",
+			clientID:  "user-chuck-1",
+			secretData: map[string][]byte{
+				"user-chuck-1": []byte("sk-somekey00000000000000000000000000"),
+			},
+			cmData: map[string]string{
+				"user-chuck-1": `{"clientId":"user-chuck-1","creator":"chuck","description":"","createdAt":"2024-01-01T00:00:00Z","modelName":"my-model","namespace":"llm-api-keys"}`,
+			},
+			wantErr: false,
+		},
+		{
+			name:       "returns error if key does not exist",
+			modelName:  "my-model",
+			clientID:   "user-nobody-1",
+			secretData: map[string][]byte{},
+			cmData:     map[string]string{},
+			wantErr:    true,
+			wantErrMsg: "user-nobody-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := buildScheme(t)
+
+			secret := makeSecret(tc.modelName, testNamespace)
+			secret.Data = tc.secretData
+			cm := makeConfigMap(tc.modelName, testNamespace)
+			cm.Data = tc.cmData
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(secret, cm).
+				Build()
+
+			mgr := secrets.NewManager(fakeClient, testNamespace)
+			err := mgr.RevokeKey(context.Background(), tc.modelName, tc.clientID)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.wantErrMsg != "" && !strings.Contains(err.Error(), tc.wantErrMsg) {
+					t.Errorf("expected error to contain %q, got: %v", tc.wantErrMsg, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("RevokeKey error: %v", err)
+			}
+
+			// Verify removed from Secret
+			updatedSecret := &corev1.Secret{}
+			secretKey := types.NamespacedName{Namespace: testNamespace, Name: tc.modelName + "-api-keys"}
+			if err := fakeClient.Get(context.Background(), secretKey, updatedSecret); err != nil {
+				t.Fatalf("Get Secret after revoke: %v", err)
+			}
+			if _, ok := updatedSecret.Data[tc.clientID]; ok {
+				t.Errorf("expected clientID %q to be removed from Secret", tc.clientID)
+			}
+
+			// Verify removed from ConfigMap
+			updatedCM := &corev1.ConfigMap{}
+			cmKey := types.NamespacedName{Namespace: testNamespace, Name: tc.modelName + "-api-key-metadata"}
+			if err := fakeClient.Get(context.Background(), cmKey, updatedCM); err != nil {
+				t.Fatalf("Get ConfigMap after revoke: %v", err)
+			}
+			if _, ok := updatedCM.Data[tc.clientID]; ok {
+				t.Errorf("expected clientID %q to be removed from ConfigMap", tc.clientID)
+			}
+		})
+	}
+}
+
+func TestCreateKeyThenListKeys(t *testing.T) {
+	scheme := buildScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			makeSecret("my-model", testNamespace),
+			makeConfigMap("my-model", testNamespace),
+		).
+		Build()
+
+	mgr := secrets.NewManager(fakeClient, testNamespace)
+
+	before := time.Now().Truncate(time.Second)
+	result, err := mgr.CreateKey(context.Background(), "my-model", "chuck", "integration test key")
+	after := time.Now().Add(time.Second)
+	if err != nil {
+		t.Fatalf("CreateKey error: %v", err)
+	}
+
+	keys, err := mgr.ListKeys(context.Background(), "my-model")
+	if err != nil {
+		t.Fatalf("ListKeys error: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+
+	key := keys[0]
+	if key.ClientID != result.ClientID {
+		t.Errorf("expected ClientID %q, got %q", result.ClientID, key.ClientID)
+	}
+	if key.Creator != "chuck" {
+		t.Errorf("expected Creator=chuck, got %q", key.Creator)
+	}
+	if key.Description != "integration test key" {
+		t.Errorf("expected Description=%q, got %q", "integration test key", key.Description)
+	}
+	if key.ModelName != "my-model" {
+		t.Errorf("expected ModelName=my-model, got %q", key.ModelName)
+	}
+	if key.Namespace != testNamespace {
+		t.Errorf("expected Namespace=%q, got %q", testNamespace, key.Namespace)
+	}
+	if key.CreatedAt.Before(before) || key.CreatedAt.After(after) {
+		t.Errorf("CreatedAt %v is outside the expected range [%v, %v]", key.CreatedAt, before, after)
+	}
+}


### PR DESCRIPTION
## Summary

Secrets manager for the key manager service. Handles API key lifecycle in the dedicated `llm-api-keys` namespace:

- CreateKey: generates `sk-<32-char-base64url>` (crypto/rand), writes to Secret, stores metadata JSON in ConfigMap
- ListKeys: returns metadata for all keys of a model (never exposes key values)
- ListKeysForUser: returns keys created by a user across all models
- RevokeKey: removes from both Secret and ConfigMap
- Client ID format: `user-<username>-<sequence>`
- 409 Conflict retry (up to 3x) for concurrent edits
- Clear errors when Secret/ConfigMap don't exist (operator hasn't created them yet)

9 tests covering all CRUD paths plus edge cases.

## Test plan

- `cd key-manager && go test ./internal/secrets/ -v` - 9 tests pass
- `cd key-manager && go test ./...` - all packages pass