### PR TITLE
Implement auth middleware for key manager

### DIFF
--- a/key-manager/internal/api/middleware.go
+++ b/key-manager/internal/api/middleware.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// UserInfo holds the authenticated user's identity extracted from JWT claims.
+type UserInfo struct {
+	Username string
+	Groups   []string
+}
+
+type contextKey string
+
+const userContextKey contextKey = "user"
+
+// UserFromContext extracts the UserInfo from the request context.
+// Returns nil, false if no user has been set.
+func UserFromContext(ctx context.Context) (*UserInfo, bool) {
+	user, ok := ctx.Value(userContextKey).(*UserInfo)
+	return user, ok && user != nil
+}
+
+// AuthConfig configures the auth middleware.
+type AuthConfig struct {
+	// GroupsClaim is the JWT claim containing groups (default: "groups").
+	GroupsClaim string
+	// CookiePrefix is the prefix for the IdToken cookie (default: "IdToken").
+	// The middleware accepts any cookie whose name starts with this prefix.
+	CookiePrefix string
+}
+
+// AuthMiddleware returns HTTP middleware that extracts user identity from JWT.
+// It does NOT validate signatures - Envoy Gateway handles that upstream.
+// Token sources (in priority order):
+//  1. Authorization: Bearer <token> header
+//  2. Cookie with name matching CookiePrefix
+func AuthMiddleware(cfg AuthConfig) func(http.Handler) http.Handler {
+	if cfg.GroupsClaim == "" {
+		cfg.GroupsClaim = "groups"
+	}
+	if cfg.CookiePrefix == "" {
+		cfg.CookiePrefix = "IdToken"
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token, err := extractToken(r, cfg.CookiePrefix)
+			if err != nil {
+				http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
+				return
+			}
+
+			user, err := parseJWT(token, cfg.GroupsClaim)
+			if err != nil {
+				http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), userContextKey, user)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// extractToken retrieves the raw JWT string from the request.
+// Checks Authorization: Bearer header first, then cookies matching the prefix.
+func extractToken(r *http.Request, cookiePrefix string) (string, error) {
+	// Check Authorization header first.
+	authHeader := r.Header.Get("Authorization")
+	if authHeader != "" {
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			return "", fmt.Errorf("Authorization header must use Bearer scheme")
+		}
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+		if token == "" {
+			return "", fmt.Errorf("Bearer token is empty")
+		}
+		return token, nil
+	}
+
+	// Fall back to cookie matching the prefix.
+	for _, cookie := range r.Cookies() {
+		if strings.HasPrefix(cookie.Name, cookiePrefix) {
+			return cookie.Value, nil
+		}
+	}
+
+	return "", fmt.Errorf("no token found in Authorization header or cookie")
+}
+
+// parseJWT decodes a JWT payload (without signature verification) and extracts user identity.
+func parseJWT(token, groupsClaim string) (*UserInfo, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT: expected 3 parts, got %d", len(parts))
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid JWT payload encoding: %w", err)
+	}
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payloadBytes, &claims); err != nil {
+		return nil, fmt.Errorf("invalid JWT payload JSON: %w", err)
+	}
+
+	username, _ := claims["preferred_username"].(string)
+	groups := extractGroups(claims, groupsClaim)
+
+	return &UserInfo{
+		Username: username,
+		Groups:   groups,
+	}, nil
+}
+
+// extractGroups reads the groups claim from JWT claims.
+// Supports both []string (array) and string (single value) formats.
+// Returns an empty slice when the claim is absent.
+func extractGroups(claims map[string]interface{}, claimName string) []string {
+	raw, ok := claims[claimName]
+	if !ok {
+		return []string{}
+	}
+
+	switch v := raw.(type) {
+	case []interface{}:
+		groups := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				groups = append(groups, s)
+			}
+		}
+		return groups
+	case string:
+		return []string{v}
+	default:
+		return []string{}
+	}
+}

--- a/key-manager/internal/api/middleware_test.go
+++ b/key-manager/internal/api/middleware_test.go
@@ -1,0 +1,254 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// makeTestJWT creates a test JWT with the given claims by base64url-encoding a JSON payload.
+// No actual signing - Envoy Gateway handles verification in production.
+func makeTestJWT(claims map[string]interface{}) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, _ := json.Marshal(claims)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	sig := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	return header + "." + payloadB64 + "." + sig
+}
+
+func defaultConfig() AuthConfig {
+	return AuthConfig{
+		GroupsClaim:  "groups",
+		CookiePrefix: "IdToken",
+	}
+}
+
+// handlerThatChecksUser is a test handler that writes the extracted username/groups to the response.
+func handlerThatChecksUser(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, ok := UserFromContext(r.Context())
+		if !ok {
+			t.Error("expected user in context, got none")
+			http.Error(w, "no user", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("X-Username", user.Username)
+		groupsJSON, _ := json.Marshal(user.Groups)
+		w.Header().Set("X-Groups", string(groupsJSON))
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	tests := []struct {
+		name           string
+		cfg            AuthConfig
+		setupRequest   func(r *http.Request)
+		wantStatus     int
+		wantUsername   string
+		wantGroups     []string
+	}{
+		{
+			name: "bearer JWT in Authorization header extracts username and groups",
+			cfg:  defaultConfig(),
+			setupRequest: func(r *http.Request) {
+				token := makeTestJWT(map[string]interface{}{
+					"preferred_username": "alice",
+					"groups":             []string{"admins", "users"},
+				})
+				r.Header.Set("Authorization", "Bearer "+token)
+			},
+			wantStatus:   http.StatusOK,
+			wantUsername: "alice",
+			wantGroups:   []string{"admins", "users"},
+		},
+		{
+			name: "JWT in IdToken cookie extracts username and groups",
+			cfg:  defaultConfig(),
+			setupRequest: func(r *http.Request) {
+				token := makeTestJWT(map[string]interface{}{
+					"preferred_username": "bob",
+					"groups":             []string{"users"},
+				})
+				r.AddCookie(&http.Cookie{Name: "IdToken-somedeployment", Value: token})
+			},
+			wantStatus:   http.StatusOK,
+			wantUsername: "bob",
+			wantGroups:   []string{"users"},
+		},
+		{
+			name: "no token returns 401",
+			cfg:  defaultConfig(),
+			setupRequest: func(r *http.Request) {
+				// no cookie, no Authorization header
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "invalid JWT without 3 parts returns 401",
+			cfg:  defaultConfig(),
+			setupRequest: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer notajwt")
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "malformed base64 in payload returns 401",
+			cfg:  defaultConfig(),
+			setupRequest: func(r *http.Request) {
+				// header.invalid-base64!.sig
+				r.Header.Set("Authorization", "Bearer aGVhZGVy.!!!notbase64!!!.c2ln")
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "groups claim as string array works",
+			cfg:  defaultConfig(),
+			setupRequest: func(r *http.Request) {
+				token := makeTestJWT(map[string]interface{}{
+					"preferred_username": "carol",
+					"groups":             []string{"eng", "ml"},
+				})
+				r.Header.Set("Authorization", "Bearer "+token)
+			},
+			wantStatus:   http.StatusOK,
+			wantUsername: "carol",
+			wantGroups:   []string{"eng", "ml"},
+		},
+		{
+			name: "groups claim as single string is converted to []string",
+			cfg:  defaultConfig(),
+			setupRequest: func(r *http.Request) {
+				token := makeTestJWT(map[string]interface{}{
+					"preferred_username": "dave",
+					"groups":             "solo-group",
+				})
+				r.Header.Set("Authorization", "Bearer "+token)
+			},
+			wantStatus:   http.StatusOK,
+			wantUsername: "dave",
+			wantGroups:   []string{"solo-group"},
+		},
+		{
+			name: "missing groups claim results in empty groups",
+			cfg:  defaultConfig(),
+			setupRequest: func(r *http.Request) {
+				token := makeTestJWT(map[string]interface{}{
+					"preferred_username": "eve",
+				})
+				r.Header.Set("Authorization", "Bearer "+token)
+			},
+			wantStatus:   http.StatusOK,
+			wantUsername: "eve",
+			wantGroups:   []string{},
+		},
+		{
+			name: "Authorization header without Bearer prefix returns 401",
+			cfg:  defaultConfig(),
+			setupRequest: func(r *http.Request) {
+				token := makeTestJWT(map[string]interface{}{
+					"preferred_username": "frank",
+				})
+				r.Header.Set("Authorization", token)
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "custom cookie prefix is respected",
+			cfg: AuthConfig{
+				GroupsClaim:  "groups",
+				CookiePrefix: "OauthToken",
+			},
+			setupRequest: func(r *http.Request) {
+				token := makeTestJWT(map[string]interface{}{
+					"preferred_username": "grace",
+					"groups":             []string{"devs"},
+				})
+				r.AddCookie(&http.Cookie{Name: "OauthToken-prod", Value: token})
+			},
+			wantStatus:   http.StatusOK,
+			wantUsername: "grace",
+			wantGroups:   []string{"devs"},
+		},
+		{
+			name: "custom groups claim name is respected",
+			cfg: AuthConfig{
+				GroupsClaim:  "cognito:groups",
+				CookiePrefix: "IdToken",
+			},
+			setupRequest: func(r *http.Request) {
+				token := makeTestJWT(map[string]interface{}{
+					"preferred_username": "henry",
+					"cognito:groups":     []string{"cognito-admins"},
+				})
+				r.Header.Set("Authorization", "Bearer "+token)
+			},
+			wantStatus:   http.StatusOK,
+			wantUsername: "henry",
+			wantGroups:   []string{"cognito-admins"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			middleware := AuthMiddleware(tc.cfg)
+			var handler http.Handler
+			if tc.wantStatus == http.StatusOK {
+				handler = middleware(handlerThatChecksUser(t))
+			} else {
+				// For error cases, inner handler should not be called.
+				handler = middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					t.Error("inner handler should not be called when auth fails")
+					w.WriteHeader(http.StatusOK)
+				}))
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			tc.setupRequest(req)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status: got %d, want %d", rec.Code, tc.wantStatus)
+			}
+
+			if tc.wantStatus == http.StatusOK {
+				gotUsername := rec.Header().Get("X-Username")
+				if gotUsername != tc.wantUsername {
+					t.Errorf("username: got %q, want %q", gotUsername, tc.wantUsername)
+				}
+
+				var gotGroups []string
+				groupsJSON := rec.Header().Get("X-Groups")
+				if err := json.Unmarshal([]byte(groupsJSON), &gotGroups); err != nil {
+					t.Fatalf("failed to parse groups header %q: %v", groupsJSON, err)
+				}
+				if len(gotGroups) != len(tc.wantGroups) {
+					t.Errorf("groups length: got %d, want %d (got %v, want %v)",
+						len(gotGroups), len(tc.wantGroups), gotGroups, tc.wantGroups)
+				} else {
+					for i := range gotGroups {
+						if gotGroups[i] != tc.wantGroups[i] {
+							t.Errorf("groups[%d]: got %q, want %q", i, gotGroups[i], tc.wantGroups[i])
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestUserFromContextReturnsFalseWhenNoUserSet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	user, ok := UserFromContext(req.Context())
+	if ok {
+		t.Errorf("expected ok=false when no user set, got ok=true with user=%v", user)
+	}
+	if user != nil {
+		t.Errorf("expected nil user when not set, got %v", user)
+	}
+}


### PR DESCRIPTION
## Summary

HTTP middleware that extracts user identity from JWTs for the key manager API:

- Checks Authorization: Bearer header first, falls back to IdToken cookie
- Decodes JWT payload (base64url, no signature verification - Envoy already validated)
- Extracts preferred_username and configurable groups claim
- Handles groups as both string array and single string
- Returns 401 for missing/malformed tokens
- Sets UserInfo on request context for downstream handlers

12 tests covering all JWT extraction paths and edge cases.

## Test plan

- `cd key-manager && go test ./internal/api/ -v` - 12 tests pass
- `cd key-manager && go test ./...` - all packages pass