### PR TITLE
Implement key manager HTTP API handlers

### DIFF
--- a/key-manager/internal/api/handler.go
+++ b/key-manager/internal/api/handler.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/models"
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/secrets"
+)
+
+// ModelLister provides model listing for the handler.
+type ModelLister interface {
+	FilterModelsForUser(groups []string) []models.ModelInfo
+}
+
+// KeyManager provides key CRUD for the handler.
+type KeyManager interface {
+	CreateKey(ctx context.Context, modelName, username, description string) (*secrets.CreateKeyResult, error)
+	ListKeys(ctx context.Context, modelName string) ([]secrets.KeyInfo, error)
+	ListKeysForUser(ctx context.Context, username string) ([]secrets.KeyInfo, error)
+	RevokeKey(ctx context.Context, modelName, clientID string) error
+}
+
+// Handler provides HTTP handlers for the key manager API.
+type Handler struct {
+	lister  ModelLister
+	secrets KeyManager
+}
+
+// NewHandler creates a Handler with the given model lister and key manager.
+func NewHandler(w ModelLister, s KeyManager) *Handler {
+	return &Handler{
+		lister:  w,
+		secrets: s,
+	}
+}
+
+// RegisterRoutes registers all API routes on the given mux.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/models", h.getModels)
+	mux.HandleFunc("GET /api/keys", h.getKeys)
+	mux.HandleFunc("POST /api/keys", h.createKey)
+	mux.HandleFunc("DELETE /api/keys/{namespace}/{model}/{clientID}", h.deleteKey)
+}
+
+// writeJSON encodes v as JSON into w with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// getModels handles GET /api/models.
+func (h *Handler) getModels(w http.ResponseWriter, r *http.Request) {
+	user, ok := UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	accessible := h.lister.FilterModelsForUser(user.Groups)
+	if accessible == nil {
+		accessible = []models.ModelInfo{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"models": accessible,
+	})
+}
+
+// getKeys handles GET /api/keys.
+func (h *Handler) getKeys(w http.ResponseWriter, r *http.Request) {
+	user, ok := UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	keys, err := h.secrets.ListKeysForUser(r.Context(), user.Username)
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	if keys == nil {
+		keys = []secrets.KeyInfo{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"keys": keys,
+	})
+}
+
+// createKeyRequest is the expected JSON body for POST /api/keys.
+type createKeyRequest struct {
+	ModelName   string `json:"modelName"`
+	Description string `json:"description"`
+}
+
+// createKey handles POST /api/keys.
+func (h *Handler) createKey(w http.ResponseWriter, r *http.Request) {
+	user, ok := UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req createKeyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request: invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	// Verify the user has access to the requested model.
+	accessible := h.lister.FilterModelsForUser(user.Groups)
+	hasAccess := false
+	for _, m := range accessible {
+		if m.Name == req.ModelName {
+			hasAccess = true
+			break
+		}
+	}
+	if !hasAccess {
+		http.Error(w, "forbidden: no access to model", http.StatusForbidden)
+		return
+	}
+
+	result, err := h.secrets.CreateKey(r.Context(), req.ModelName, user.Username, req.Description)
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"clientId": result.ClientID,
+		"apiKey":   result.APIKey,
+	})
+}
+
+// deleteKey handles DELETE /api/keys/{namespace}/{model}/{clientID}.
+func (h *Handler) deleteKey(w http.ResponseWriter, r *http.Request) {
+	user, ok := UserFromContext(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	namespace := r.PathValue("namespace")
+	modelName := r.PathValue("model")
+	clientID := r.PathValue("clientID")
+
+	// List all keys for the model to find and verify ownership.
+	keys, err := h.secrets.ListKeys(r.Context(), modelName)
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Find the key by clientID and namespace.
+	var found *secrets.KeyInfo
+	for i := range keys {
+		if keys[i].ClientID == clientID && keys[i].Namespace == namespace {
+			found = &keys[i]
+			break
+		}
+	}
+
+	if found == nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	if found.Creator != user.Username {
+		http.Error(w, "forbidden: key belongs to another user", http.StatusForbidden)
+		return
+	}
+
+	if err := h.secrets.RevokeKey(r.Context(), modelName, clientID); err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/key-manager/internal/api/handler_test.go
+++ b/key-manager/internal/api/handler_test.go
@@ -1,0 +1,417 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/models"
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/secrets"
+)
+
+// --- mock implementations ---
+
+type mockModelLister struct {
+	models []models.ModelInfo
+}
+
+func (m *mockModelLister) FilterModelsForUser(groups []string) []models.ModelInfo {
+	return m.models
+}
+
+type mockKeyManager struct {
+	keys          []secrets.KeyInfo
+	createResult  *secrets.CreateKeyResult
+	createErr     error
+	revokeErr     error
+	listUserErr   error
+}
+
+func (m *mockKeyManager) CreateKey(ctx context.Context, modelName, username, description string) (*secrets.CreateKeyResult, error) {
+	return m.createResult, m.createErr
+}
+
+func (m *mockKeyManager) ListKeys(ctx context.Context, modelName string) ([]secrets.KeyInfo, error) {
+	return m.keys, nil
+}
+
+func (m *mockKeyManager) ListKeysForUser(ctx context.Context, username string) ([]secrets.KeyInfo, error) {
+	if m.listUserErr != nil {
+		return nil, m.listUserErr
+	}
+	return m.keys, nil
+}
+
+func (m *mockKeyManager) RevokeKey(ctx context.Context, modelName, clientID string) error {
+	return m.revokeErr
+}
+
+// --- helpers ---
+
+// contextWithUser returns a context that has the given user set.
+func contextWithUser(ctx context.Context, user *UserInfo) context.Context {
+	return context.WithValue(ctx, userContextKey, user)
+}
+
+func newHandlerWithMocks(lister ModelLister, km KeyManager) *Handler {
+	return &Handler{
+		lister:  lister,
+		secrets: km,
+	}
+}
+
+func callHandler(t *testing.T, h *Handler, method, path string, body interface{}, user *UserInfo) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshaling body: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(method, path, bytes.NewReader(bodyBytes))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	if user != nil {
+		req = req.WithContext(contextWithUser(req.Context(), user))
+	}
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
+// --- test data ---
+
+var testUser = &UserInfo{
+	Username: "chuck",
+	Groups:   []string{"ml-team", "admins"},
+}
+
+var testModels = []models.ModelInfo{
+	{Name: "llama3", Namespace: "default", ModelName: "meta-llama/Meta-Llama-3-8B", Public: false, Groups: []string{"ml-team"}},
+	{Name: "phi3", Namespace: "default", ModelName: "microsoft/Phi-3-mini", Public: true},
+}
+
+var testKeys = []secrets.KeyInfo{
+	{
+		ClientID:    "user-chuck-1",
+		Creator:     "chuck",
+		Description: "my key",
+		CreatedAt:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		ModelName:   "llama3",
+		Namespace:   "default",
+	},
+	{
+		ClientID:    "user-alice-1",
+		Creator:     "alice",
+		Description: "alice key",
+		CreatedAt:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+		ModelName:   "llama3",
+		Namespace:   "default",
+	},
+}
+
+// --- GET /api/models tests ---
+
+func TestGetModels(t *testing.T) {
+	tests := []struct {
+		name           string
+		user           *UserInfo
+		models         []models.ModelInfo
+		wantStatus     int
+		wantModelCount int
+	}{
+		{
+			name:           "returns filtered models for authenticated user",
+			user:           testUser,
+			models:         testModels,
+			wantStatus:     http.StatusOK,
+			wantModelCount: 2,
+		},
+		{
+			name:           "returns empty list when no models accessible",
+			user:           testUser,
+			models:         []models.ModelInfo{},
+			wantStatus:     http.StatusOK,
+			wantModelCount: 0,
+		},
+		{
+			name:       "returns 401 when no user in context",
+			user:       nil,
+			models:     testModels,
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHandlerWithMocks(
+				&mockModelLister{models: tc.models},
+				&mockKeyManager{},
+			)
+			rr := callHandler(t, h, http.MethodGet, "/api/models", nil, tc.user)
+
+			if rr.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body: %s)", rr.Code, tc.wantStatus, rr.Body.String())
+			}
+			if tc.wantStatus != http.StatusOK {
+				return
+			}
+
+			var resp struct {
+				Models []models.ModelInfo `json:"models"`
+			}
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decoding response: %v", err)
+			}
+			if len(resp.Models) != tc.wantModelCount {
+				t.Errorf("model count = %d, want %d", len(resp.Models), tc.wantModelCount)
+			}
+		})
+	}
+}
+
+// --- GET /api/keys tests ---
+
+func TestGetKeys(t *testing.T) {
+	tests := []struct {
+		name       string
+		user       *UserInfo
+		keys       []secrets.KeyInfo
+		wantStatus int
+		wantCount  int
+	}{
+		{
+			name:       "returns user keys",
+			user:       testUser,
+			keys:       testKeys,
+			wantStatus: http.StatusOK,
+			wantCount:  2,
+		},
+		{
+			name:       "returns empty list when no keys",
+			user:       testUser,
+			keys:       []secrets.KeyInfo{},
+			wantStatus: http.StatusOK,
+			wantCount:  0,
+		},
+		{
+			name:       "returns 401 when no user in context",
+			user:       nil,
+			keys:       testKeys,
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHandlerWithMocks(
+				&mockModelLister{},
+				&mockKeyManager{keys: tc.keys},
+			)
+			rr := callHandler(t, h, http.MethodGet, "/api/keys", nil, tc.user)
+
+			if rr.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body: %s)", rr.Code, tc.wantStatus, rr.Body.String())
+			}
+			if tc.wantStatus != http.StatusOK {
+				return
+			}
+
+			var resp struct {
+				Keys []secrets.KeyInfo `json:"keys"`
+			}
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decoding response: %v", err)
+			}
+			if len(resp.Keys) != tc.wantCount {
+				t.Errorf("key count = %d, want %d", len(resp.Keys), tc.wantCount)
+			}
+		})
+	}
+}
+
+// --- POST /api/keys tests ---
+
+func TestCreateKey(t *testing.T) {
+	type createKeyRequest struct {
+		ModelName   string `json:"modelName"`
+		Description string `json:"description"`
+	}
+
+	tests := []struct {
+		name           string
+		user           *UserInfo
+		body           interface{}
+		accessModels   []models.ModelInfo
+		createResult   *secrets.CreateKeyResult
+		createErr      error
+		wantStatus     int
+		wantClientID   string
+		wantAPIKey     string
+	}{
+		{
+			name: "creates key and returns 201 with apiKey",
+			user: testUser,
+			body: createKeyRequest{ModelName: "llama3", Description: "my key"},
+			accessModels: []models.ModelInfo{
+				{Name: "llama3", Namespace: "default", ModelName: "meta-llama/Meta-Llama-3-8B"},
+			},
+			createResult: &secrets.CreateKeyResult{
+				ClientID: "user-chuck-1",
+				APIKey:   "sk-abc123",
+			},
+			wantStatus:   http.StatusCreated,
+			wantClientID: "user-chuck-1",
+			wantAPIKey:   "sk-abc123",
+		},
+		{
+			name: "returns 403 when user doesn't have model access",
+			user: testUser,
+			body: createKeyRequest{ModelName: "restricted-model", Description: "my key"},
+			accessModels: []models.ModelInfo{
+				{Name: "llama3", Namespace: "default", ModelName: "meta-llama/Meta-Llama-3-8B"},
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:         "returns 400 for invalid JSON body",
+			user:         testUser,
+			body:         nil, // will send raw invalid JSON below
+			accessModels: testModels,
+			wantStatus:   http.StatusBadRequest,
+		},
+		{
+			name:       "returns 401 when no user in context",
+			user:       nil,
+			body:       createKeyRequest{ModelName: "llama3", Description: "my key"},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHandlerWithMocks(
+				&mockModelLister{models: tc.accessModels},
+				&mockKeyManager{createResult: tc.createResult, createErr: tc.createErr},
+			)
+
+			var req *http.Request
+			if tc.name == "returns 400 for invalid JSON body" {
+				req = httptest.NewRequest(http.MethodPost, "/api/keys", bytes.NewBufferString("{invalid json"))
+				req.Header.Set("Content-Type", "application/json")
+			} else {
+				var bodyBytes []byte
+				if tc.body != nil {
+					var err error
+					bodyBytes, err = json.Marshal(tc.body)
+					if err != nil {
+						t.Fatalf("marshaling body: %v", err)
+					}
+				}
+				req = httptest.NewRequest(http.MethodPost, "/api/keys", bytes.NewReader(bodyBytes))
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			if tc.user != nil {
+				req = req.WithContext(contextWithUser(req.Context(), tc.user))
+			}
+
+			mux := http.NewServeMux()
+			h.RegisterRoutes(mux)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, req)
+
+			if rr.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body: %s)", rr.Code, tc.wantStatus, rr.Body.String())
+			}
+			if tc.wantStatus != http.StatusCreated {
+				return
+			}
+
+			var resp struct {
+				ClientID string `json:"clientId"`
+				APIKey   string `json:"apiKey"`
+			}
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decoding response: %v", err)
+			}
+			if resp.ClientID != tc.wantClientID {
+				t.Errorf("clientId = %q, want %q", resp.ClientID, tc.wantClientID)
+			}
+			if resp.APIKey != tc.wantAPIKey {
+				t.Errorf("apiKey = %q, want %q", resp.APIKey, tc.wantAPIKey)
+			}
+		})
+	}
+}
+
+// --- DELETE /api/keys/{namespace}/{model}/{clientID} tests ---
+
+func TestDeleteKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		user       *UserInfo
+		path       string
+		keys       []secrets.KeyInfo
+		revokeErr  error
+		wantStatus int
+	}{
+		{
+			name:  "returns 204 when key belongs to user",
+			user:  testUser,
+			path:  "/api/keys/default/llama3/user-chuck-1",
+			keys:  testKeys,
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name: "returns 403 when user doesn't own the key",
+			user: testUser,
+			path: "/api/keys/default/llama3/user-alice-1",
+			keys: testKeys,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "returns 404 when key not found",
+			user:       testUser,
+			path:       "/api/keys/default/llama3/user-chuck-99",
+			keys:       testKeys,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "returns 401 when no user in context",
+			user:       nil,
+			path:       "/api/keys/default/llama3/user-chuck-1",
+			keys:       testKeys,
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHandlerWithMocks(
+				&mockModelLister{},
+				&mockKeyManager{keys: tc.keys, revokeErr: tc.revokeErr},
+			)
+			rr := callHandler(t, h, http.MethodDelete, tc.path, nil, tc.user)
+
+			if rr.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body: %s)", rr.Code, tc.wantStatus, rr.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

HTTP API handlers for the key manager service:

- GET /api/models - returns models filtered by user's OIDC groups
- GET /api/keys - returns user's API keys across all accessible models
- POST /api/keys - creates a new API key (returns key value once), 403 if no model access
- DELETE /api/keys/{namespace}/{model}/{clientID} - revokes a key, 403 if not owner

Uses interfaces (ModelLister, KeyManager) for testability with lightweight mocks. Go 1.22+ method-pattern routing and PathValue for path params.

15 tests covering all endpoints, auth enforcement, and error paths.

## Test plan

- `cd key-manager && go test ./internal/api/ -v` - 15 tests pass
- `cd key-manager && go test ./...` - all packages pass