### PR TITLE
Add web UI, wire main.go, create Dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 CLAUDE.md
 docs/superpowers/
+.claude/

--- a/key-manager/Dockerfile
+++ b/key-manager/Dockerfile
@@ -1,7 +1,7 @@
 # Build context must be the repository root so both modules are available.
 # Usage: docker build -f key-manager/Dockerfile -t key-manager:dev .
 
-FROM golang:1.25rc1 AS builder
+FROM golang:1.24 AS builder
 
 # Allow the Go toolchain to auto-download the exact version declared in go.mod.
 ENV GOTOOLCHAIN=auto

--- a/key-manager/Dockerfile
+++ b/key-manager/Dockerfile
@@ -1,0 +1,39 @@
+# Build context must be the repository root so both modules are available.
+# Usage: docker build -f key-manager/Dockerfile -t key-manager:dev .
+
+FROM golang:1.25rc1 AS builder
+
+# Allow the Go toolchain to auto-download the exact version declared in go.mod.
+ENV GOTOOLCHAIN=auto
+
+WORKDIR /workspace
+
+# Copy module files for both modules so dependency download is cached.
+COPY operator/go.mod operator/go.sum operator/
+COPY key-manager/go.mod key-manager/go.sum key-manager/
+
+# Copy the operator API package that the key-manager depends on via replace.
+COPY operator/api/ operator/api/
+
+# Download dependencies before copying source to maximise layer cache hits.
+WORKDIR /workspace/key-manager
+RUN go mod download
+
+# Copy key-manager source.
+COPY key-manager/ /workspace/key-manager/
+
+# Build the binary.
+RUN CGO_ENABLED=0 GOOS=linux go build -o key-manager ./cmd/main.go
+
+# ---------------------------------------------------------------------------
+# Runtime image
+# ---------------------------------------------------------------------------
+FROM gcr.io/distroless/static:nonroot
+
+WORKDIR /
+
+COPY --from=builder /workspace/key-manager/key-manager .
+
+USER 65532:65532
+
+ENTRYPOINT ["/key-manager"]

--- a/key-manager/cmd/main.go
+++ b/key-manager/cmd/main.go
@@ -1,11 +1,175 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"io/fs"
 	"log"
+	"log/slog"
 	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
+
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/api"
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/audit"
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/models"
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/secrets"
+	"github.com/nebari-dev/nebari-llm-serving-pack/key-manager/internal/ui"
 )
 
 func main() {
-	log.Println("key-manager starting on :8080")
-	log.Fatal(http.ListenAndServe(":8080", http.DefaultServeMux))
+	// 1. Parse config from env vars.
+	apiKeysNamespace := getEnvOrDefault("LLM_API_KEYS_NAMESPACE", "llm-api-keys")
+	groupsClaim := getEnvOrDefault("LLM_OIDC_GROUPS_CLAIM", "groups")
+	cookiePrefix := getEnvOrDefault("LLM_AUTH_COOKIE_PREFIX", "IdToken")
+	auditIntervalStr := getEnvOrDefault("LLM_AUDIT_INTERVAL", "5m")
+	oidcUserinfoURL := os.Getenv("LLM_OIDC_USERINFO_URL") // optional
+	listenAddr := getEnvOrDefault("LLM_LISTEN_ADDR", ":8080")
+
+	auditInterval, err := time.ParseDuration(auditIntervalStr)
+	if err != nil {
+		log.Fatalf("invalid LLM_AUDIT_INTERVAL %q: %v", auditIntervalStr, err)
+	}
+
+	logger := slog.Default()
+
+	// 2. Set up K8s client with LLMModel scheme registered.
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		log.Fatalf("adding client-go scheme: %v", err)
+	}
+	if err := llmv1alpha1.AddToScheme(scheme); err != nil {
+		log.Fatalf("adding LLM scheme: %v", err)
+	}
+
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatalf("getting in-cluster config: %v", err)
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		log.Fatalf("creating k8s client: %v", err)
+	}
+
+	// 3. Create components.
+	watcher := models.NewWatcher(k8sClient)
+	secretsMgr := secrets.NewManager(k8sClient, apiKeysNamespace)
+	handler := api.NewHandler(watcher, secretsMgr)
+
+	// 4. Set up context with signal handling for graceful shutdown.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// 5. Initial model sync.
+	if err := watcher.Sync(ctx); err != nil {
+		log.Printf("initial model sync failed (will retry): %v", err)
+	}
+
+	// 6. Start periodic model sync every 30s.
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := watcher.Sync(ctx); err != nil {
+					logger.Error("model sync failed", "error", err)
+				}
+			}
+		}
+	}()
+
+	// 7. Start audit if userinfo URL is configured.
+	if oidcUserinfoURL != "" {
+		lookup := makeUserinfoLookup(oidcUserinfoURL)
+		auditor := audit.NewAuditor(watcher, secretsMgr, lookup, auditInterval, logger)
+		go auditor.Start(ctx)
+		logger.Info("audit loop started", "interval", auditInterval, "userinfo_url", oidcUserinfoURL)
+	} else {
+		logger.Info("audit loop disabled: LLM_OIDC_USERINFO_URL not set")
+	}
+
+	// 8. Set up HTTP mux and routes.
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	// Serve static UI files at root.
+	staticFS, err := fs.Sub(ui.StaticFiles, "static")
+	if err != nil {
+		log.Fatalf("creating sub-FS for static files: %v", err)
+	}
+	mux.Handle("GET /", http.FileServer(http.FS(staticFS)))
+
+	// Apply auth middleware only to /api/ routes.
+	authMW := api.AuthMiddleware(api.AuthConfig{
+		GroupsClaim:  groupsClaim,
+		CookiePrefix: cookiePrefix,
+	})
+
+	finalHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			authMW(mux).ServeHTTP(w, r)
+		} else {
+			mux.ServeHTTP(w, r)
+		}
+	})
+
+	srv := &http.Server{
+		Addr:         listenAddr,
+		Handler:      finalHandler,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// Shut down the HTTP server when the context is cancelled.
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			logger.Error("http server shutdown error", "error", err)
+		}
+	}()
+
+	log.Printf("key-manager listening on %s", listenAddr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("http server error: %v", err)
+	}
+}
+
+// getEnvOrDefault returns the value of the named environment variable, or
+// the provided default if the variable is not set or is empty.
+func getEnvOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+// makeUserinfoLookup returns a UserGroupsLookup that calls the OIDC userinfo endpoint.
+// For v0.1 this is a stub that returns an error so the auditor skips revocation
+// safely until token exchange is implemented.
+func makeUserinfoLookup(userinfoURL string) audit.UserGroupsLookup {
+	return func(ctx context.Context, username string) ([]string, error) {
+		// TODO: Implement OIDC userinfo lookup.
+		// This requires either:
+		//   1. A service account token that can query the Keycloak admin API.
+		//   2. Token exchange to obtain a token for the user.
+		// Returning an error causes the auditor to skip revocation (fail-safe).
+		return nil, fmt.Errorf("userinfo lookup not yet implemented (url: %s, user: %s)", userinfoURL, username)
+	}
 }

--- a/key-manager/internal/ui/embed.go
+++ b/key-manager/internal/ui/embed.go
@@ -1,0 +1,6 @@
+package ui
+
+import "embed"
+
+//go:embed static/*
+var StaticFiles embed.FS

--- a/key-manager/internal/ui/static/app.js
+++ b/key-manager/internal/ui/static/app.js
@@ -1,0 +1,310 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+let allModels = [];
+
+// ---------------------------------------------------------------------------
+// DOM helpers
+// ---------------------------------------------------------------------------
+function $(id) { return document.getElementById(id); }
+
+function showError(message) {
+  const banner = $('error-banner');
+  banner.textContent = message;
+  banner.classList.remove('hidden');
+}
+
+function clearError() {
+  $('error-banner').classList.add('hidden');
+}
+
+function showFieldError(id, message) {
+  const el = $(id);
+  el.textContent = message;
+  el.classList.remove('hidden');
+}
+
+function clearFieldError(id) {
+  $(id).classList.add('hidden');
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+async function apiFetch(method, path, body) {
+  const opts = {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+  };
+  if (body !== undefined) {
+    opts.body = JSON.stringify(body);
+  }
+  const resp = await fetch(path, opts);
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`${method} ${path} failed (${resp.status}): ${text.trim()}`);
+  }
+  if (resp.status === 204) return null;
+  return resp.json();
+}
+
+// ---------------------------------------------------------------------------
+// Models section
+// ---------------------------------------------------------------------------
+async function loadModels() {
+  try {
+    const data = await apiFetch('GET', '/api/models');
+    allModels = data.models || [];
+    renderModels(allModels);
+    populateModelSelect(allModels);
+  } catch (err) {
+    $('models-loading').classList.add('hidden');
+    $('models-container').classList.remove('hidden');
+    $('models-container').innerHTML = '<p class="field-error">Failed to load models: ' + escapeHtml(err.message) + '</p>';
+  }
+}
+
+function renderModels(models) {
+  $('models-loading').classList.add('hidden');
+  const container = $('models-container');
+  container.classList.remove('hidden');
+
+  if (models.length === 0) {
+    container.innerHTML = '<p class="empty-state">No models accessible to your account.</p>';
+    return;
+  }
+
+  // Group by namespace
+  const byNs = {};
+  for (const m of models) {
+    const ns = m.Namespace || m.namespace || 'default';
+    if (!byNs[ns]) byNs[ns] = [];
+    byNs[ns].push(m);
+  }
+
+  const grid = document.createElement('div');
+  grid.className = 'models-grid';
+
+  for (const [ns, nsModels] of Object.entries(byNs)) {
+    const group = document.createElement('div');
+    group.className = 'namespace-group';
+
+    const heading = document.createElement('h3');
+    heading.textContent = ns;
+    group.appendChild(heading);
+
+    const list = document.createElement('ul');
+    list.className = 'model-list';
+
+    for (const m of nsModels) {
+      const li = document.createElement('li');
+      const name = m.Name || m.name || '';
+      const isPublic = m.Public || m.public || false;
+      li.className = 'model-tag' + (isPublic ? ' public' : '');
+      li.textContent = name;
+      list.appendChild(li);
+    }
+
+    group.appendChild(list);
+    grid.appendChild(group);
+  }
+
+  container.innerHTML = '';
+  container.appendChild(grid);
+}
+
+function populateModelSelect(models) {
+  const sel = $('model-select');
+  // Remove all options except the placeholder
+  while (sel.options.length > 1) sel.remove(1);
+
+  for (const m of models) {
+    const name = m.Name || m.name || '';
+    const ns = m.Namespace || m.namespace || '';
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = ns ? `${ns}/${name}` : name;
+    sel.appendChild(opt);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Keys section
+// ---------------------------------------------------------------------------
+async function loadKeys() {
+  try {
+    const data = await apiFetch('GET', '/api/keys');
+    renderKeys(data.keys || []);
+  } catch (err) {
+    $('keys-loading').classList.add('hidden');
+    $('keys-container').classList.remove('hidden');
+    $('keys-container').innerHTML = '<p class="field-error">Failed to load keys: ' + escapeHtml(err.message) + '</p>';
+  }
+}
+
+function renderKeys(keys) {
+  $('keys-loading').classList.add('hidden');
+  const container = $('keys-container');
+  container.classList.remove('hidden');
+
+  if (keys.length === 0) {
+    container.innerHTML = '<p class="empty-state">No API keys yet. Create one above.</p>';
+    return;
+  }
+
+  const table = document.createElement('table');
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th>Client ID</th>
+        <th>Model</th>
+        <th>Namespace</th>
+        <th>Description</th>
+        <th>Created</th>
+        <th>Action</th>
+      </tr>
+    </thead>
+  `;
+
+  const tbody = document.createElement('tbody');
+  for (const k of keys) {
+    const tr = document.createElement('tr');
+    const clientId = k.clientId || '';
+    const modelName = k.modelName || '';
+    const ns = k.namespace || '';
+    const desc = k.description || '';
+    const created = k.createdAt ? new Date(k.createdAt).toLocaleDateString() : '';
+
+    tr.innerHTML = `
+      <td><code>${escapeHtml(clientId)}</code></td>
+      <td>${escapeHtml(modelName)}</td>
+      <td>${escapeHtml(ns)}</td>
+      <td>${escapeHtml(desc)}</td>
+      <td>${escapeHtml(created)}</td>
+      <td></td>
+    `;
+
+    const revokeBtn = document.createElement('button');
+    revokeBtn.className = 'btn-danger';
+    revokeBtn.textContent = 'Revoke';
+    revokeBtn.addEventListener('click', () => revokeKey(ns, modelName, clientId, tr));
+    tr.cells[5].appendChild(revokeBtn);
+
+    tbody.appendChild(tr);
+  }
+  table.appendChild(tbody);
+
+  container.innerHTML = '';
+  container.appendChild(table);
+}
+
+async function revokeKey(namespace, modelName, clientId, rowEl) {
+  if (!confirm(`Revoke key "${clientId}" for model "${modelName}"? This cannot be undone.`)) {
+    return;
+  }
+  try {
+    await apiFetch('DELETE', `/api/keys/${encodeURIComponent(namespace)}/${encodeURIComponent(modelName)}/${encodeURIComponent(clientId)}`);
+    rowEl.remove();
+    // If the table body is now empty, re-render the empty state
+    const tbody = document.querySelector('#keys-container tbody');
+    if (tbody && tbody.rows.length === 0) {
+      $('keys-container').innerHTML = '<p class="empty-state">No API keys yet. Create one above.</p>';
+    }
+  } catch (err) {
+    showError('Failed to revoke key: ' + err.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Create key form
+// ---------------------------------------------------------------------------
+$('create-key-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  clearFieldError('create-error');
+  clearError();
+
+  const modelName = $('model-select').value;
+  const description = $('description-input').value.trim();
+
+  if (!modelName) {
+    showFieldError('create-error', 'Please select a model.');
+    return;
+  }
+
+  const btn = $('create-btn');
+  btn.disabled = true;
+  btn.textContent = 'Creating...';
+
+  try {
+    const result = await apiFetch('POST', '/api/keys', { modelName, description });
+    showKeyModal(result.apiKey, result.clientId);
+    // Reload the keys list after creating
+    $('keys-loading').classList.remove('hidden');
+    $('keys-container').classList.add('hidden');
+    loadKeys();
+    // Reset form
+    $('model-select').value = '';
+    $('description-input').value = '';
+  } catch (err) {
+    showFieldError('create-error', 'Failed to create key: ' + err.message);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Create Key';
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Key modal
+// ---------------------------------------------------------------------------
+function showKeyModal(apiKey, clientId) {
+  $('modal-key-value').textContent = apiKey;
+  $('modal-client-id').textContent = 'Client ID: ' + clientId;
+  $('key-modal').classList.remove('hidden');
+}
+
+$('copy-btn').addEventListener('click', async () => {
+  const key = $('modal-key-value').textContent;
+  try {
+    await navigator.clipboard.writeText(key);
+    $('copy-btn').textContent = 'Copied!';
+    setTimeout(() => { $('copy-btn').textContent = 'Copy'; }, 2000);
+  } catch {
+    // Fallback: select the text
+    const range = document.createRange();
+    range.selectNode($('modal-key-value'));
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+  }
+});
+
+$('modal-close-btn').addEventListener('click', () => {
+  $('key-modal').classList.add('hidden');
+  $('modal-key-value').textContent = '';
+});
+
+// Close modal on overlay click
+$('key-modal').addEventListener('click', (e) => {
+  if (e.target === $('key-modal')) {
+    $('key-modal').classList.add('hidden');
+    $('modal-key-value').textContent = '';
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ---------------------------------------------------------------------------
+// Initialise
+// ---------------------------------------------------------------------------
+loadModels();
+loadKeys();

--- a/key-manager/internal/ui/static/index.html
+++ b/key-manager/internal/ui/static/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LLM API Key Manager</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <header>
+    <h1>LLM API Key Manager</h1>
+  </header>
+
+  <main>
+    <div id="error-banner" class="error-banner hidden"></div>
+
+    <section id="models-section">
+      <h2>Available Models</h2>
+      <div id="models-loading" class="loading">Loading models...</div>
+      <div id="models-container" class="hidden"></div>
+    </section>
+
+    <section id="create-key-section">
+      <h2>Create API Key</h2>
+      <form id="create-key-form">
+        <div class="form-row">
+          <label for="model-select">Model</label>
+          <select id="model-select" name="modelName" required>
+            <option value="">-- select a model --</option>
+          </select>
+        </div>
+        <div class="form-row">
+          <label for="description-input">Description</label>
+          <input type="text" id="description-input" name="description" placeholder="e.g. my notebook" maxlength="200">
+        </div>
+        <div class="form-row">
+          <button type="submit" id="create-btn">Create Key</button>
+        </div>
+        <div id="create-error" class="field-error hidden"></div>
+      </form>
+    </section>
+
+    <section id="keys-section">
+      <h2>My API Keys</h2>
+      <div id="keys-loading" class="loading">Loading keys...</div>
+      <div id="keys-container" class="hidden"></div>
+    </section>
+  </main>
+
+  <!-- Modal for displaying new API key -->
+  <div id="key-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal">
+      <h3 id="modal-title">API Key Created</h3>
+      <p class="modal-warning">Copy this key now. It will not be shown again.</p>
+      <div class="key-display">
+        <code id="modal-key-value"></code>
+        <button id="copy-btn" type="button">Copy</button>
+      </div>
+      <p id="modal-client-id" class="modal-meta"></p>
+      <button id="modal-close-btn" type="button" class="btn-primary">Done</button>
+    </div>
+  </div>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/key-manager/internal/ui/static/style.css
+++ b/key-manager/internal/ui/static/style.css
@@ -1,0 +1,275 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #222;
+  background: #f5f5f5;
+}
+
+header {
+  background: #1a3a5c;
+  color: #fff;
+  padding: 1rem 2rem;
+}
+
+header h1 {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+main {
+  max-width: 960px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+section {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1.5rem;
+}
+
+section h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+/* Error banner */
+.error-banner {
+  background: #fce8e8;
+  border: 1px solid #e88;
+  color: #a00;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+}
+
+.field-error {
+  color: #c00;
+  font-size: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+/* Loading state */
+.loading {
+  color: #666;
+  font-style: italic;
+}
+
+/* Models grid */
+.models-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.namespace-group h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #555;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.model-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.model-tag {
+  background: #e8f0fb;
+  border: 1px solid #b3c8ef;
+  color: #1a3a5c;
+  padding: 0.25rem 0.6rem;
+  border-radius: 3px;
+  font-size: 0.85rem;
+}
+
+.model-tag.public::after {
+  content: " (public)";
+  color: #2a7a2a;
+  font-size: 0.75rem;
+}
+
+.empty-state {
+  color: #888;
+  font-style: italic;
+}
+
+/* Create key form */
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.85rem;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+select,
+input[type="text"] {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  font-size: 0.875rem;
+  max-width: 400px;
+  width: 100%;
+}
+
+select:focus,
+input[type="text"]:focus {
+  outline: 2px solid #4a90d9;
+  outline-offset: 1px;
+  border-color: #4a90d9;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 3px;
+  padding: 0.45rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+button[type="submit"],
+.btn-primary {
+  background: #1a3a5c;
+  color: #fff;
+}
+
+button[type="submit"]:hover,
+.btn-primary:hover {
+  background: #255080;
+}
+
+button[type="submit"]:disabled {
+  background: #999;
+  cursor: not-allowed;
+}
+
+/* Keys table */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  background: #f0f0f0;
+  border: 1px solid #ddd;
+  font-weight: 600;
+}
+
+td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #eee;
+  vertical-align: middle;
+}
+
+tr:nth-child(even) td {
+  background: #fafafa;
+}
+
+.btn-danger {
+  background: #c0392b;
+  color: #fff;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.btn-danger:hover {
+  background: #a93226;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 6px;
+  padding: 2rem;
+  max-width: 560px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal h3 {
+  font-size: 1.1rem;
+}
+
+.modal-warning {
+  background: #fff8e1;
+  border: 1px solid #f0c040;
+  padding: 0.5rem 0.75rem;
+  border-radius: 3px;
+  font-weight: 600;
+  color: #7a5800;
+}
+
+.key-display {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.key-display code {
+  flex: 1;
+  background: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+#copy-btn {
+  background: #eee;
+  border: 1px solid #ccc;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+#copy-btn:hover {
+  background: #ddd;
+}
+
+.modal-meta {
+  color: #555;
+  font-size: 0.85rem;
+}
+
+.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary

Completes the key manager service:

**Web UI** (embedded SPA, no build step):
- Model list grouped by namespace
- Key table with create/revoke actions
- One-time key display modal with copy button
- Vanilla HTML/JS/CSS, embedded via Go embed package

**main.go wiring:**
- In-cluster K8s client setup with LLMModel scheme
- Watcher, secrets manager, HTTP handler, auditor construction
- Periodic model sync (30s)
- Selective auth middleware (API routes only, not static files)
- Graceful shutdown on SIGTERM/SIGINT
- Audit stub (userinfo lookup not yet implemented, fail-safe)

**Dockerfiles:**
- key-manager: multi-stage build from repo root (needs both modules for local replace)
- operator: existing kubebuilder Dockerfile verified working
- .claude/ added to gitignore

## Test plan

- `cd key-manager && go build ./...` - clean build
- `cd key-manager && go test ./...` - all packages pass
- Docker builds tested during development