### PR TITLE
Add dev environment, CI workflows, and getting started guide

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,34 @@
+name: Build Images
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-operator:
+    name: Build operator image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build operator image
+        run: docker build -f operator/Dockerfile -t llm-operator:dev operator/
+
+  build-key-manager:
+    name: Build key-manager image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build key-manager image
+        run: docker build -f key-manager/Dockerfile -t llm-key-manager:dev .
+
+  build-mock-vllm:
+    name: Build mock-vllm image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build mock-vllm image
+        run: docker build -t mock-vllm:dev dev/mock-vllm/

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,54 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-operator:
+    name: Lint operator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: operator/go.mod
+          cache-dependency-path: operator/go.sum
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.4.0
+          working-directory: operator
+
+  lint-key-manager:
+    name: Lint key-manager
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: key-manager/go.mod
+          cache-dependency-path: key-manager/go.sum
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.4.0
+          working-directory: key-manager
+
+  lint-helm:
+    name: Lint Helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint chart
+        run: helm lint charts/nebari-llm-serving/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-operator:
+    name: Test operator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: operator/go.mod
+          cache-dependency-path: operator/go.sum
+
+      - name: Run tests
+        working-directory: operator
+        run: make test
+
+  test-key-manager:
+    name: Test key-manager
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: key-manager/go.mod
+          cache-dependency-path: key-manager/go.sum
+
+      - name: Run tests
+        working-directory: key-manager
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ response = client.chat.completions.create(
 
 ## Configuration
 
+See [docs/getting-started.md](docs/getting-started.md) for a local dev walkthrough.
+
 See [docs/design.md](docs/design.md) for the full design document, including:
 
 - Complete LLMModel CRD spec and status fields
@@ -146,18 +148,36 @@ Admin applies LLMModel CR
 
 ## Development
 
+See [docs/getting-started.md](docs/getting-started.md) for a full walkthrough of the local dev environment.
+
 ```bash
-# Local dev cluster with kind
+# Create kind cluster with all dependencies
 cd dev && make setup
 
-# Run operator locally
-cd operator && go run ./cmd/main.go
+# Build and load images into the cluster
+make build-images && make load-images
 
-# Run key manager locally
-cd key-manager && go run ./cmd/main.go
+# Deploy operator and key manager
+make deploy
 
-# Run tests
-cd operator && go test ./...
+# Apply a test model
+make apply-test-model
+
+# Watch reconciliation
+kubectl -n llm-serving get llmmodels -w
+
+# Tail logs
+make logs-operator
+make logs-key-manager
+
+# Tear down
+make teardown
+```
+
+Run tests directly:
+
+```bash
+cd operator && make test
 cd key-manager && go test ./...
 ```
 

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,0 +1,61 @@
+CLUSTER_NAME ?= llm-serving-test
+
+.PHONY: setup teardown build-images load-images deploy deploy-operator deploy-key-manager apply-test-model logs-operator logs-key-manager clean help
+
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+setup: ## Create kind cluster and install dependencies
+	kind create cluster --name $(CLUSTER_NAME)
+	# cert-manager
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+	kubectl -n cert-manager rollout status deployment/cert-manager-webhook --timeout=120s
+	# Gateway API CRDs
+	kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+	# GIE CRDs (v1.4.0, includes graduated k8s.io group)
+	kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.4.0/manifests.yaml
+	# Envoy Gateway
+	helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.3.0 -n envoy-gateway-system --create-namespace
+	kubectl -n envoy-gateway-system rollout status deployment/envoy-gateway --timeout=120s
+	# Envoy AI Gateway
+	helm upgrade -i aieg-crd oci://docker.io/envoyproxy/ai-gateway-crds-helm --version v0.5.0 -n envoy-ai-gateway-system --create-namespace
+	helm upgrade -i aieg oci://docker.io/envoyproxy/ai-gateway-helm --version v0.5.0 -n envoy-ai-gateway-system
+	kubectl -n envoy-ai-gateway-system wait --timeout=120s deployment/ai-gateway-controller --for=condition=Available
+	# LLMModel CRD
+	kubectl apply -f ../charts/nebari-llm-serving/crds/llmmodel-crd.yaml
+	# Test Gateways
+	kubectl apply -f gateways.yaml
+
+teardown: ## Delete kind cluster
+	kind delete cluster --name $(CLUSTER_NAME)
+
+build-images: ## Build all Docker images
+	docker build -f ../operator/Dockerfile -t llm-operator:dev ../operator/
+	docker build -f ../key-manager/Dockerfile -t llm-key-manager:dev ../
+	docker build -t mock-vllm:dev mock-vllm/
+
+load-images: ## Load images into kind
+	kind load docker-image llm-operator:dev llm-key-manager:dev mock-vllm:dev --name $(CLUSTER_NAME)
+
+deploy: deploy-operator deploy-key-manager ## Deploy everything
+
+deploy-operator: ## Deploy operator
+	kubectl apply -f manifests/operator.yaml
+	kubectl apply -f manifests/cert-manager-config.yaml
+	kubectl apply -f manifests/webhook.yaml
+	kubectl -n llm-operator-system rollout status deployment/llm-operator --timeout=60s
+
+deploy-key-manager: ## Deploy key manager
+	kubectl apply -f manifests/key-manager.yaml
+	kubectl -n llm-operator-system rollout status deployment/llm-key-manager --timeout=60s
+
+apply-test-model: ## Apply test model
+	kubectl apply -f manifests/test-model.yaml
+
+logs-operator: ## Tail operator logs
+	kubectl -n llm-operator-system logs -f deployment/llm-operator
+
+logs-key-manager: ## Tail key manager logs
+	kubectl -n llm-operator-system logs -f deployment/llm-key-manager
+
+clean: teardown ## Alias for teardown

--- a/dev/gateways.yaml
+++ b/dev/gateways.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: nebari-gateway-class
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: nebari-gateway
+  namespace: envoy-gateway-system
+spec:
+  gatewayClassName: nebari-gateway-class
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: nebari-internal-gateway
+  namespace: envoy-gateway-system
+spec:
+  gatewayClassName: nebari-gateway-class
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,173 @@
+# Getting Started (Local Dev Cluster)
+
+This guide walks through setting up a local development environment using [kind](https://kind.sigs.k8s.io/) to test the nebari-llm-serving-pack without a full Nebari deployment.
+
+## Prerequisites
+
+Install the following tools before proceeding:
+
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) v0.20+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [helm](https://helm.sh/docs/intro/install/) v3.12+
+- [Docker](https://docs.docker.com/get-docker/) (or compatible container runtime)
+- [Go](https://go.dev/doc/install) 1.22+ (for building the operator and key manager)
+
+## 1. Clone the repo
+
+```bash
+git clone https://github.com/nebari-dev/nebari-llm-serving-pack
+cd nebari-llm-serving-pack
+```
+
+## 2. Create the dev cluster
+
+The `dev/Makefile` automates cluster creation and dependency installation:
+
+```bash
+cd dev
+make setup
+```
+
+This creates a kind cluster named `llm-serving-test` and installs:
+- cert-manager (for webhook TLS)
+- Gateway API CRDs
+- Gateway API Inference Extension CRDs
+- Envoy Gateway
+- Envoy AI Gateway
+- The `LLMModel` CRD
+- Test `GatewayClass` and `Gateway` resources
+
+The setup takes a few minutes. You can watch progress in the terminal output.
+
+## 3. Build and load images
+
+Build the operator, key manager, and mock vLLM images, then load them into the kind cluster:
+
+```bash
+make build-images
+make load-images
+```
+
+The mock vLLM image simulates a vLLM server for testing without a GPU. It responds to OpenAI-compatible API calls with canned responses.
+
+## 4. Deploy the operator and key manager
+
+```bash
+make deploy
+```
+
+This applies the manifests in `dev/manifests/` and waits for the deployments to become ready. You can also deploy them individually:
+
+```bash
+make deploy-operator     # operator only
+make deploy-key-manager  # key manager only
+```
+
+Verify the deployments:
+
+```bash
+kubectl -n llm-operator-system get pods
+```
+
+Expected output:
+```
+NAME                               READY   STATUS    RESTARTS   AGE
+llm-key-manager-xxxxxxxxx-xxxxx    1/1     Running   0          30s
+llm-operator-xxxxxxxxx-xxxxx       1/1     Running   0          45s
+```
+
+## 5. Deploy a test model
+
+Apply the test `LLMModel` resource, which uses the mock vLLM image:
+
+```bash
+make apply-test-model
+```
+
+This creates an `LLMModel` named `test-model` in the `llm-serving` namespace. The operator reconciles it and creates the supporting resources.
+
+## 6. Watch reconciliation
+
+Watch the `LLMModel` status update as the operator reconciles:
+
+```bash
+kubectl -n llm-serving get llmmodels -w
+```
+
+You should see the `READY` column transition through states as each sub-resource is created. Once all reconcilers complete, the model shows `Ready`.
+
+Check the operator logs if anything looks stuck:
+
+```bash
+make logs-operator
+```
+
+## 7. Verify resources
+
+Once the model is ready, verify the created resources:
+
+```bash
+kubectl -n llm-serving get all
+kubectl -n llm-serving get aigatewayroutes
+kubectl -n envoy-gateway-system get securitypolicies
+```
+
+The operator creates:
+- A `Deployment` running the mock vLLM pod
+- A `Service` for the deployment
+- An `InferencePool` for intelligent request scheduling
+- `AIGatewayRoute` resources for external (API key) and internal (JWT) access
+- `SecurityPolicy` resources for auth enforcement
+- A `ReferenceGrant` to allow cross-namespace policy references
+
+## 8. Test the key manager API
+
+The key manager exposes an HTTP API for generating and revoking API keys. In the dev cluster, forward its port:
+
+```bash
+kubectl -n llm-operator-system port-forward svc/llm-key-manager 8080:8080 &
+```
+
+List models (requires a JWT in the `Authorization` header or an identity cookie):
+
+```bash
+# With a fake JWT (the dev server accepts any token for testing)
+curl -s http://localhost:8080/api/v1/models \
+  -H "Authorization: Bearer fake-jwt-token" | jq .
+```
+
+Create an API key for the test model:
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/keys \
+  -H "Authorization: Bearer fake-jwt-token" \
+  -H "Content-Type: application/json" \
+  -d '{"modelName": "test-model", "namespace": "llm-serving"}' | jq .
+```
+
+The response includes the generated key. Keys are stored as Kubernetes Secrets in the `llm-api-keys` namespace:
+
+```bash
+kubectl -n llm-api-keys get secrets
+```
+
+## 9. Cleanup
+
+When you are done, delete the kind cluster:
+
+```bash
+make teardown
+```
+
+Or equivalently:
+
+```bash
+make clean
+```
+
+## Next steps
+
+- Read [docs/design.md](design.md) for the full architecture and CRD spec
+- See `dev/manifests/test-model.yaml` for an annotated example `LLMModel`
+- Check the Helm chart at `charts/nebari-llm-serving/` for production deployment values
+- For a real deployment with GPUs and OIDC, see the [Quick start](../README.md#quick-start) in the main README


### PR DESCRIPTION
## Summary

**Dev environment (dev/Makefile):**
- `make setup` - creates kind cluster, installs cert-manager, Gateway API, GIE, Envoy Gateway, Envoy AI Gateway, LLMModel CRD, test Gateways
- `make build-images && make load-images` - build and load operator, key-manager, mock-vllm
- `make deploy` - deploy operator + key manager
- `make apply-test-model` - deploy mock model
- `make teardown` - cleanup

**CI workflows:**
- lint.yaml: golangci-lint on operator/ and key-manager/, helm lint on chart
- test.yaml: `make test` for operator (envtest), `go test ./...` for key-manager
- build-images.yaml: verify Docker builds for all three images

**Documentation:**
- docs/getting-started.md: step-by-step local dev walkthrough
- README.md: updated development section with Makefile targets, links to getting started guide

Closes #15, closes #16

## Test plan

- `helm lint charts/nebari-llm-serving/` - passes
- CI workflows use correct paths and Go versions
- Getting started guide follows the exact steps we validated in integration testing