### PR TITLE
Fix EPP crash by supplying EndpointPickerConfig

### DIFF
--- a/charts/nebari-llm-serving/values.yaml
+++ b/charts/nebari-llm-serving/values.yaml
@@ -40,7 +40,7 @@ keyManager:
 operator:
   image:
     repository: ghcr.io/nebari-dev/nebari-llm-serving-pack/operator
-    tag: dev-epp-config-fix
+    tag: latest
     pullPolicy: Always
 
 # Namespace where API keys (Secrets) are stored

--- a/charts/nebari-llm-serving/values.yaml
+++ b/charts/nebari-llm-serving/values.yaml
@@ -40,7 +40,7 @@ keyManager:
 operator:
   image:
     repository: ghcr.io/nebari-dev/nebari-llm-serving-pack/operator
-    tag: latest
+    tag: dev-epp-config-fix
     pullPolicy: Always
 
 # Namespace where API keys (Secrets) are stored

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -8,7 +8,9 @@ require (
 	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
 	k8s.io/client-go v0.34.0
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.22.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -91,10 +93,8 @@ require (
 	k8s.io/component-base v0.34.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/operator/internal/controller/llmmodel_controller.go
+++ b/operator/internal/controller/llmmodel_controller.go
@@ -437,6 +437,15 @@ func (r *LLMModelReconciler) reconcileInferencePoolResources(
 		return fmt.Errorf("reconciling EPP Service: %w", err)
 	}
 
+	// EPP ConfigMap (must exist before Deployment so the volume mount resolves)
+	pool.EPPConfigMap.Namespace = model.Namespace
+	if err := reconcilers.SetOwnerReference(model, pool.EPPConfigMap, r.Scheme); err != nil {
+		return fmt.Errorf("setting owner on EPP ConfigMap: %w", err)
+	}
+	if err := r.createOrUpdateConfigMap(ctx, pool.EPPConfigMap); err != nil {
+		return fmt.Errorf("reconciling EPP ConfigMap: %w", err)
+	}
+
 	// EPP Deployment
 	pool.EPPDeployment.Namespace = model.Namespace
 	if err := reconcilers.SetOwnerReference(model, pool.EPPDeployment, r.Scheme); err != nil {

--- a/operator/internal/controller/reconcilers/inferencepool.go
+++ b/operator/internal/controller/reconcilers/inferencepool.go
@@ -1,14 +1,20 @@
-// Resource specs based on GIE inferencepool chart v1.4.0
+// Resource specs based on GIE inferencepool chart v1.4.0 and the EPP deployment
+// template from llm-d-inference-scheduler v0.6.1-rc.1.
 package reconcilers
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
 	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
@@ -54,7 +60,10 @@ func BuildInferencePoolResources(model *llmv1alpha1.LLMModel, cfg *config.Operat
 	eppName := model.Name + "-epp"
 
 	inferencePool := buildInferencePool(model, labels)
-	eppConfigMap := buildEPPConfigMap(eppName, labels)
+	eppConfigMap, err := buildEPPConfigMap(model, eppName, labels)
+	if err != nil {
+		return nil, fmt.Errorf("building EPP ConfigMap: %w", err)
+	}
 	eppDeployment := buildEPPDeployment(model, eppName, labels)
 	eppService := buildEPPService(model, eppName, labels)
 	eppSA := buildEPPServiceAccount(eppName, labels)
@@ -78,16 +87,37 @@ func eppConfigMapName(eppName string) string {
 	return eppName + "-config"
 }
 
-func buildEPPConfigMap(eppName string, labels map[string]string) *corev1.ConfigMap {
+// buildEPPConfigMap renders the EndpointPickerConfig YAML for the EPP deployment.
+// If the user provides spec.advanced.inferencePool.schedulerConfig, that value
+// is used verbatim; otherwise the minimal built-in default is used.
+func buildEPPConfigMap(model *llmv1alpha1.LLMModel, eppName string, labels map[string]string) (*corev1.ConfigMap, error) {
+	configYAML, err := renderEPPConfig(model.Spec.Advanced.InferencePool.SchedulerConfig)
+	if err != nil {
+		return nil, err
+	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   eppConfigMapName(eppName),
 			Labels: labels,
 		},
 		Data: map[string]string{
-			eppConfigFileName: eppDefaultConfig,
+			eppConfigFileName: configYAML,
 		},
+	}, nil
+}
+
+// renderEPPConfig returns the EPP config YAML to put in the ConfigMap. When the
+// user supplies schedulerConfig, its bytes (JSON from the API server) are
+// converted to YAML and used directly; otherwise the built-in default is used.
+func renderEPPConfig(override *runtime.RawExtension) (string, error) {
+	if override == nil || len(override.Raw) == 0 {
+		return eppDefaultConfig, nil
 	}
+	yamlBytes, err := yaml.JSONToYAML(override.Raw)
+	if err != nil {
+		return "", fmt.Errorf("converting schedulerConfig JSON to YAML: %w", err)
+	}
+	return string(yamlBytes), nil
 }
 
 func buildInferencePool(model *llmv1alpha1.LLMModel, labels map[string]string) *unstructured.Unstructured {
@@ -136,7 +166,7 @@ func buildEPPDeployment(model *llmv1alpha1.LLMModel, eppName string, labels map[
 		ProbeHandler: corev1.ProbeHandler{
 			GRPC: &corev1.GRPCAction{
 				Port:    9003,
-				Service: ptrTo("envoy.service.ext_proc.v3.ExternalProcessor"),
+				Service: ptr.To("envoy.service.ext_proc.v3.ExternalProcessor"),
 			},
 		},
 		InitialDelaySeconds: 5,
@@ -158,6 +188,9 @@ func buildEPPDeployment(model *llmv1alpha1.LLMModel, eppName string, labels map[
 			"--grpc-health-port", "9003",
 			"--metrics-port", "9090",
 			"--config-file", eppConfigMountDir + "/" + eppConfigFileName,
+			// TODO: expose --zap-encoder and --v via operator config; `--v 4` is
+			// debug-verbose for steady-state production but matches upstream
+			// reference deployments and aids post-crash-fix triage.
 			"--zap-encoder", "json",
 			"--v", "4",
 		},
@@ -219,8 +252,6 @@ func buildEPPDeployment(model *llmv1alpha1.LLMModel, eppName string, labels map[
 		},
 	}
 }
-
-func ptrTo[T any](v T) *T { return &v }
 
 func buildEPPService(model *llmv1alpha1.LLMModel, eppName string, labels map[string]string) *corev1.Service {
 	return &corev1.Service{

--- a/operator/internal/controller/reconcilers/inferencepool.go
+++ b/operator/internal/controller/reconcilers/inferencepool.go
@@ -15,12 +15,31 @@ import (
 )
 
 const (
-	eppImage = "ghcr.io/llm-d/llm-d-inference-scheduler:v0.6.1-rc.1"
+	eppImage          = "ghcr.io/llm-d/llm-d-inference-scheduler:v0.6.1-rc.1"
+	eppConfigMountDir = "/etc/epp"
+	eppConfigFileName = "epp-config.yaml"
+	eppConfigVolume   = "epp-config"
 )
+
+// eppDefaultConfig is the minimal EndpointPickerConfig the EPP loads via --config-file.
+// Without an explicit config, the GIE falls back to a default that includes
+// prefix-cache-scorer, which requires a tokenizer (sidecar or HF_TOKEN) we don't
+// ship. This config uses only built-in plugins that don't require tokenization.
+const eppDefaultConfig = `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: max-score-picker
+- type: single-profile-handler
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: max-score-picker
+`
 
 // InferencePoolResources holds the Kubernetes resources for the Gateway API Inference Extension.
 type InferencePoolResources struct {
 	InferencePool     *unstructured.Unstructured // inference.networking.k8s.io/v1 InferencePool
+	EPPConfigMap      *corev1.ConfigMap
 	EPPDeployment     *appsv1.Deployment
 	EPPService        *corev1.Service
 	EPPServiceAccount *corev1.ServiceAccount
@@ -35,6 +54,7 @@ func BuildInferencePoolResources(model *llmv1alpha1.LLMModel, cfg *config.Operat
 	eppName := model.Name + "-epp"
 
 	inferencePool := buildInferencePool(model, labels)
+	eppConfigMap := buildEPPConfigMap(eppName, labels)
 	eppDeployment := buildEPPDeployment(model, eppName, labels)
 	eppService := buildEPPService(model, eppName, labels)
 	eppSA := buildEPPServiceAccount(eppName, labels)
@@ -43,12 +63,31 @@ func BuildInferencePoolResources(model *llmv1alpha1.LLMModel, cfg *config.Operat
 
 	return &InferencePoolResources{
 		InferencePool:     inferencePool,
+		EPPConfigMap:      eppConfigMap,
 		EPPDeployment:     eppDeployment,
 		EPPService:        eppService,
 		EPPServiceAccount: eppSA,
 		EPPRole:           eppRole,
 		EPPRoleBinding:    eppRoleBinding,
 	}, nil
+}
+
+// eppConfigMapName returns the ConfigMap name that holds the EPP configuration
+// for the given EPP deployment.
+func eppConfigMapName(eppName string) string {
+	return eppName + "-config"
+}
+
+func buildEPPConfigMap(eppName string, labels map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   eppConfigMapName(eppName),
+			Labels: labels,
+		},
+		Data: map[string]string{
+			eppConfigFileName: eppDefaultConfig,
+		},
+	}
 }
 
 func buildInferencePool(model *llmv1alpha1.LLMModel, labels map[string]string) *unstructured.Unstructured {
@@ -93,19 +132,44 @@ func buildEPPDeployment(model *llmv1alpha1.LLMModel, eppName string, labels map[
 	}
 	eppLabels["app.kubernetes.io/name"] = "epp"
 
+	grpcHealthProbe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			GRPC: &corev1.GRPCAction{
+				Port:    9003,
+				Service: ptrTo("envoy.service.ext_proc.v3.ExternalProcessor"),
+			},
+		},
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       10,
+	}
+
 	container := corev1.Container{
 		Name:  "epp",
 		Image: eppImage,
 		Ports: []corev1.ContainerPort{
 			{Name: "grpc", ContainerPort: 9002, Protocol: corev1.ProtocolTCP},
+			{Name: "grpc-health", ContainerPort: 9003, Protocol: corev1.ProtocolTCP},
 			{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
 		},
 		Args: []string{
 			"--pool-name", model.Name,
 			"--pool-namespace", model.Namespace,
 			"--grpc-port", "9002",
+			"--grpc-health-port", "9003",
 			"--metrics-port", "9090",
+			"--config-file", eppConfigMountDir + "/" + eppConfigFileName,
+			"--zap-encoder", "json",
+			"--v", "4",
 		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      eppConfigVolume,
+				MountPath: eppConfigMountDir,
+				ReadOnly:  true,
+			},
+		},
+		LivenessProbe:  grpcHealthProbe.DeepCopy(),
+		ReadinessProbe: grpcHealthProbe.DeepCopy(),
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -138,11 +202,25 @@ func buildEPPDeployment(model *llmv1alpha1.LLMModel, eppName string, labels map[
 				Spec: corev1.PodSpec{
 					ServiceAccountName: eppName,
 					Containers:         []corev1.Container{container},
+					Volumes: []corev1.Volume{
+						{
+							Name: eppConfigVolume,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: eppConfigMapName(eppName),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 	}
 }
+
+func ptrTo[T any](v T) *T { return &v }
 
 func buildEPPService(model *llmv1alpha1.LLMModel, eppName string, labels map[string]string) *corev1.Service {
 	return &corev1.Service{

--- a/operator/internal/controller/reconcilers/inferencepool_test.go
+++ b/operator/internal/controller/reconcilers/inferencepool_test.go
@@ -6,6 +6,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
 	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
@@ -342,6 +344,67 @@ func TestBuildInferencePoolResources(t *testing.T) { //nolint:gocyclo // table-d
 				}
 				if !strings.Contains(data, "max-score-picker") {
 					t.Errorf("expected max-score-picker plugin in config, got: %s", data)
+				}
+			},
+		},
+		{
+			name:  "EPP ConfigMap: default config is valid YAML",
+			model: defaultInferencePoolModel(),
+			cfg:   defaultInferencePoolConfig(),
+			check: func(t *testing.T, result *InferencePoolResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				data := result.EPPConfigMap.Data["epp-config.yaml"]
+				parsed := map[string]any{}
+				if err := yaml.Unmarshal([]byte(data), &parsed); err != nil {
+					t.Fatalf("default epp-config.yaml is not valid YAML: %v\ncontent:\n%s", err, data)
+				}
+				if parsed["kind"] != "EndpointPickerConfig" {
+					t.Errorf("expected parsed kind=EndpointPickerConfig, got %v", parsed["kind"])
+				}
+			},
+		},
+		{
+			name: "EPP ConfigMap: user schedulerConfig override replaces default",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultInferencePoolModel()
+				m.Spec.Advanced.InferencePool.SchedulerConfig = &runtime.RawExtension{
+					Raw: []byte(`{"apiVersion":"inference.networking.x-k8s.io/v1alpha1","kind":"EndpointPickerConfig","plugins":[{"type":"prefix-cache-scorer"},{"type":"max-score-picker"}],"schedulingProfiles":[{"name":"default","plugins":[{"pluginRef":"max-score-picker"},{"pluginRef":"prefix-cache-scorer","weight":2}]}]}`),
+				}
+				return m
+			}(),
+			cfg: defaultInferencePoolConfig(),
+			check: func(t *testing.T, result *InferencePoolResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				data := result.EPPConfigMap.Data["epp-config.yaml"]
+				if !strings.Contains(data, "prefix-cache-scorer") {
+					t.Errorf("expected override to include prefix-cache-scorer, got: %s", data)
+				}
+				parsed := map[string]any{}
+				if err := yaml.Unmarshal([]byte(data), &parsed); err != nil {
+					t.Fatalf("rendered override is not valid YAML: %v", err)
+				}
+			},
+		},
+		{
+			name: "EPP ConfigMap: invalid schedulerConfig JSON returns error",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultInferencePoolModel()
+				m.Spec.Advanced.InferencePool.SchedulerConfig = &runtime.RawExtension{
+					Raw: []byte(`{not valid json`),
+				}
+				return m
+			}(),
+			cfg: defaultInferencePoolConfig(),
+			check: func(t *testing.T, result *InferencePoolResources, err error) {
+				if err == nil {
+					t.Fatal("expected error for invalid schedulerConfig JSON, got nil")
+				}
+				if result != nil {
+					t.Error("expected nil result on error")
 				}
 			},
 		},

--- a/operator/internal/controller/reconcilers/inferencepool_test.go
+++ b/operator/internal/controller/reconcilers/inferencepool_test.go
@@ -1,8 +1,10 @@
 package reconcilers
 
 import (
+	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
@@ -201,7 +203,7 @@ func TestBuildInferencePoolResources(t *testing.T) { //nolint:gocyclo // table-d
 			},
 		},
 		{
-			name:  "EPP Deployment: container ports 9002 and 9090",
+			name:  "EPP Deployment: container ports 9002, 9003 and 9090",
 			model: defaultInferencePoolModel(),
 			cfg:   defaultInferencePoolConfig(),
 			check: func(t *testing.T, result *InferencePoolResources, err error) {
@@ -210,10 +212,14 @@ func TestBuildInferencePoolResources(t *testing.T) { //nolint:gocyclo // table-d
 				}
 				ports := result.EPPDeployment.Spec.Template.Spec.Containers[0].Ports
 				foundGRPC := false
+				foundGRPCHealth := false
 				foundMetrics := false
 				for _, p := range ports {
 					if p.ContainerPort == 9002 && p.Name == "grpc" {
 						foundGRPC = true
+					}
+					if p.ContainerPort == 9003 && p.Name == "grpc-health" {
+						foundGRPCHealth = true
 					}
 					if p.ContainerPort == 9090 && p.Name == "metrics" {
 						foundMetrics = true
@@ -222,13 +228,16 @@ func TestBuildInferencePoolResources(t *testing.T) { //nolint:gocyclo // table-d
 				if !foundGRPC {
 					t.Error("expected container port 9002 named grpc")
 				}
+				if !foundGRPCHealth {
+					t.Error("expected container port 9003 named grpc-health")
+				}
 				if !foundMetrics {
 					t.Error("expected container port 9090 named metrics")
 				}
 			},
 		},
 		{
-			name:  "EPP Deployment: args include pool-name and pool-namespace",
+			name:  "EPP Deployment: args include pool-name, pool-namespace, ports, and config-file",
 			model: defaultInferencePoolModel(),
 			cfg:   defaultInferencePoolConfig(),
 			check: func(t *testing.T, result *InferencePoolResources, err error) {
@@ -239,7 +248,101 @@ func TestBuildInferencePoolResources(t *testing.T) { //nolint:gocyclo // table-d
 				assertArgValue(t, args, "--pool-name", testPoolModelName)
 				assertArgValue(t, args, "--pool-namespace", "test-ns")
 				assertArgValue(t, args, "--grpc-port", "9002")
+				assertArgValue(t, args, "--grpc-health-port", "9003")
 				assertArgValue(t, args, "--metrics-port", "9090")
+				assertArgValue(t, args, "--config-file", "/etc/epp/epp-config.yaml")
+			},
+		},
+		{
+			name:  "EPP Deployment: gRPC health probes on port 9003",
+			model: defaultInferencePoolModel(),
+			cfg:   defaultInferencePoolConfig(),
+			check: func(t *testing.T, result *InferencePoolResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				c := result.EPPDeployment.Spec.Template.Spec.Containers[0]
+				if c.LivenessProbe == nil || c.LivenessProbe.GRPC == nil {
+					t.Fatal("expected gRPC liveness probe")
+				}
+				if c.LivenessProbe.GRPC.Port != 9003 {
+					t.Errorf("expected liveness probe port 9003, got %d", c.LivenessProbe.GRPC.Port)
+				}
+				if c.ReadinessProbe == nil || c.ReadinessProbe.GRPC == nil {
+					t.Fatal("expected gRPC readiness probe")
+				}
+				if c.ReadinessProbe.GRPC.Port != 9003 {
+					t.Errorf("expected readiness probe port 9003, got %d", c.ReadinessProbe.GRPC.Port)
+				}
+			},
+		},
+		{
+			name:  "EPP Deployment: config volume mounted from ConfigMap at /etc/epp",
+			model: defaultInferencePoolModel(),
+			cfg:   defaultInferencePoolConfig(),
+			check: func(t *testing.T, result *InferencePoolResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				spec := result.EPPDeployment.Spec.Template.Spec
+				// VolumeMount
+				var mount *corev1.VolumeMount
+				for i, m := range spec.Containers[0].VolumeMounts {
+					if m.Name == "epp-config" {
+						mount = &spec.Containers[0].VolumeMounts[i]
+						break
+					}
+				}
+				if mount == nil {
+					t.Fatal("expected volumeMount named epp-config")
+				}
+				if mount.MountPath != "/etc/epp" {
+					t.Errorf("expected mountPath /etc/epp, got %q", mount.MountPath)
+				}
+				// Volume
+				var vol *corev1.Volume
+				for i, v := range spec.Volumes {
+					if v.Name == "epp-config" {
+						vol = &spec.Volumes[i]
+						break
+					}
+				}
+				if vol == nil {
+					t.Fatal("expected volume named epp-config")
+				}
+				if vol.ConfigMap == nil {
+					t.Fatal("expected epp-config volume to reference a ConfigMap")
+				}
+				if vol.ConfigMap.Name != testPoolEPPName+"-config" {
+					t.Errorf("expected ConfigMap name %s-config, got %q", testPoolEPPName, vol.ConfigMap.Name)
+				}
+			},
+		},
+		{
+			name:  "EPP ConfigMap: contains epp-config.yaml with EndpointPickerConfig kind",
+			model: defaultInferencePoolModel(),
+			cfg:   defaultInferencePoolConfig(),
+			check: func(t *testing.T, result *InferencePoolResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				cm := result.EPPConfigMap
+				if cm == nil {
+					t.Fatal("expected EPPConfigMap to be non-nil")
+				}
+				if cm.Name != testPoolEPPName+"-config" {
+					t.Errorf("expected ConfigMap name %s-config, got %q", testPoolEPPName, cm.Name)
+				}
+				data, ok := cm.Data["epp-config.yaml"]
+				if !ok {
+					t.Fatal("expected epp-config.yaml key in ConfigMap Data")
+				}
+				if !strings.Contains(data, "kind: EndpointPickerConfig") {
+					t.Errorf("expected EndpointPickerConfig kind in config, got: %s", data)
+				}
+				if !strings.Contains(data, "max-score-picker") {
+					t.Errorf("expected max-score-picker plugin in config, got: %s", data)
+				}
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- The endpoint picker (EPP) container crashes at startup with a nil pointer panic in `loader.InstantiateAndConfigure` because the operator launches it without `--config-file` or `--config-text`. Without either flag the GIE falls back to a default config that includes `prefix-cache-scorer`, which requires a tokenizer we don't ship.
- The operator now renders a minimal `EndpointPickerConfig` (only `max-score-picker` + `single-profile-handler`, no tokenizer needed) into a ConfigMap, mounts it at `/etc/epp`, and passes `--config-file /etc/epp/epp-config.yaml`. Also adds the gRPC health port (9003) with liveness/readiness probes and `--zap-encoder json` + `--v 4` to match upstream reference deployments.
- Chart default `operator.image.tag` is temporarily bumped to `dev-epp-config-fix` for end-to-end validation. See note below before merging.

## Observed failure
```
panic: runtime error: invalid memory address or nil pointer dereference
sigs.k8s.io/gateway-api-inference-extension/pkg/epp/config/loader.InstantiateAndConfigure
    configloader.go:83
sigs.k8s.io/gateway-api-inference-extension/cmd/epp/runner.(*Runner).parseConfigurationPhaseTwo
    runner.go:446
```

## References
- EPP flag definitions: [gateway-api-inference-extension / pkg/epp/server/options.go](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/pkg/epp/server/options.go)
- Upstream reference deployment using `--config-file`: [llm-d-inference-scheduler / deploy/environments/dev/base-kind-istio/patch-deployments.yaml](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/deploy/environments/dev/base-kind-istio/patch-deployments.yaml)
- Built-in plugin registrations (confirms `max-score-picker` and `single-profile-handler` are GIE built-ins): [picker/maxscore](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/pkg/epp/framework/plugins/scheduling/picker/maxscore/picker.go), [profile/single_profile_handler](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/pkg/epp/framework/plugins/scheduling/profile/single_profile_handler.go)

## Follow-ups not in this PR
- Prefix-cache scoring and other tokenizer-dependent plugins. Needs either a published stable `uds-tokenizer` image or an HF_TOKEN-based flow.
- Exposing the EPP config via the LLMModel CR so users can override the scheduler profile without patching the operator.

## Note for reviewers
`values.yaml` references the dev image tag `dev-epp-config-fix`. Please retag the published image to a stable tag (e.g. bump `:latest` or promote to a release tag) and update `values.yaml` accordingly before merging to main, so downstream users of the chart aren't pointed at a rotating dev tag.

## Test plan
- [x] `go test ./...` in `operator/` - all green (reconcilers, controller integration, webhook).
- [x] `go build ./...` clean.
- [x] `golangci-lint run` clean on touched files.
- [ ] Deploy the `dev-epp-config-fix` image to a cluster and confirm the EPP pod reaches `Ready 1/1` instead of `CrashLoopBackOff`.
- [ ] Confirm InferencePool routing works end-to-end against a vLLM model.