### PR TITLE
Add NebariApp route and landing-page tile for key-manager UI

### DIFF
--- a/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.keyManager.enabled .Values.keyManager.nebariApp.enabled }}
+apiVersion: reconcilers.nebari.dev/v1
+kind: NebariApp
+metadata:
+  name: {{ include "nebari-llm-serving.fullname" . }}-key-manager
+  namespace: {{ include "nebari-llm-serving.operatorNamespace" . }}
+  labels:
+    {{- include "nebari-llm-serving.labels" . | nindent 4 }}
+spec:
+  hostname: {{ required "keyManager.nebariApp.hostname is required when keyManager.nebariApp.enabled=true" .Values.keyManager.nebariApp.hostname | quote }}
+  gateway: {{ .Values.keyManager.nebariApp.gateway | quote }}
+  service:
+    name: {{ include "nebari-llm-serving.fullname" . }}-key-manager
+    port: 8080
+  auth:
+    enabled: true
+    provider: keycloak
+    provisionClient: {{ .Values.keyManager.nebariApp.auth.provisionClient }}
+    scopes:
+      {{- toYaml .Values.keyManager.nebariApp.auth.scopes | nindent 6 }}
+  {{- with .Values.keyManager.nebariApp.landingPage }}
+  landingPage:
+    enabled: {{ .enabled }}
+    {{- if .enabled }}
+    displayName: {{ required "keyManager.nebariApp.landingPage.displayName is required when landingPage is enabled" .displayName | quote }}
+    {{- with .description }}
+    description: {{ . | quote }}
+    {{- end }}
+    {{- with .category }}
+    category: {{ . | quote }}
+    {{- end }}
+    {{- with .icon }}
+    icon: {{ . | quote }}
+    {{- end }}
+    {{- with .priority }}
+    priority: {{ . }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/nebari-llm-serving/values.yaml
+++ b/charts/nebari-llm-serving/values.yaml
@@ -36,6 +36,38 @@ keyManager:
     pullPolicy: Always
   auditInterval: 5m
   oidcUserinfoURL: ""
+  # nebariApp - the NebariApp CR that exposes the key-manager UI via the
+  # nebari-operator (HTTPRoute, TLS cert, Keycloak client, landing-page tile).
+  # Set enabled=false when installing standalone without a Nebari cluster.
+  nebariApp:
+    enabled: true
+    # hostname - fully qualified hostname for the UI. Required when enabled.
+    # Example: llm-keys.your-cluster.example.com
+    hostname: ""
+    # gateway - which Nebari shared gateway to attach the HTTPRoute to.
+    # Valid values: "public" or "internal".
+    gateway: public
+    auth:
+      # provisionClient: true tells nebari-operator to create a dedicated
+      # Keycloak client for the UI and write credentials to the Secret
+      # <nebariapp-name>-oidc-client. The gateway uses these to enforce
+      # OIDC login before forwarding to the key-manager.
+      provisionClient: true
+      scopes:
+        - openid
+        - profile
+        - email
+        - groups
+    # landingPage controls how the UI appears on the Nebari landing page.
+    landingPage:
+      enabled: true
+      displayName: "LLM API Keys"
+      description: "Manage your personal API keys for LLM inference."
+      category: "Platform"
+      # icon - one of the built-in keys (jupyter, grafana, prometheus,
+      # keycloak, argocd, kubernetes) or a URL to a custom image.
+      icon: "keycloak"
+      priority: 100
 
 operator:
   image:

--- a/examples/argocd-application.yaml
+++ b/examples/argocd-application.yaml
@@ -55,6 +55,19 @@ spec:
 
           keyManager:
             enabled: true
+            # nebariApp exposes the key-manager UI through the nebari-operator
+            # (HTTPRoute + TLS + Keycloak client + landing-page tile).
+            nebariApp:
+              enabled: true
+              hostname: "llm-keys.your-cluster.example.com"
+              gateway: public
+              landingPage:
+                enabled: true
+                displayName: "LLM API Keys"
+                description: "Manage your personal API keys for LLM inference."
+                category: "Platform"
+                icon: "keycloak"
+                priority: 100
 
     # Source 2: LLMModel CRs from your cluster config repo
     - repoURL: https://github.com/your-org/your-cluster-config.git
@@ -66,6 +79,12 @@ spec:
     namespace: nebari-llm-serving-system
 
   syncPolicy:
+    # The NebariApp operator requires nebari.dev/managed=true on any namespace
+    # it reconciles resources into. Let ArgoCD manage that label on the
+    # destination namespace so it's set on first sync.
+    managedNamespaceMetadata:
+      labels:
+        nebari.dev/managed: "true"
     automated:
       prune: true
       selfHeal: true
@@ -73,6 +92,10 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+      # The NebariApp CRD is installed by nebari-operator. ArgoCD dry-runs
+      # all resources before syncing, so it may report NebariApp as missing
+      # if sync ordering races with CRD install; skip the dry-run rather
+      # than fail the preflight check.
       - SkipDryRunOnMissingResource=true
     retry:
       limit: 5


### PR DESCRIPTION
## Summary
- Ship the key-manager UI as a first-class NebariApp. The chart already deploys the Go binary and ClusterIP Service; this adds a NebariApp template so the nebari-operator provisions the HTTPRoute, TLS cert, Keycloak client, and landing-page tile from a single CR.
- Default to \`nebariApp.enabled: true\` on this Nebari-specific pack; \`hostname\` is \`required\` and surfaces a helpful error if the user forgets it. Flip the switch off for standalone installs.
- Example \`examples/argocd-application.yaml\` now shows the hostname + landing-page fields and has ArgoCD manage the \`nebari.dev/managed=true\` namespace label the nebari-operator requires.

## Auth model
- Gateway enforces Keycloak OIDC via \`auth.enabled=true\`/\`provisionClient=true\`; a dedicated Keycloak client is created and credentials land in \`<nebariapp-name>-oidc-client\` Secret.
- The key-manager's existing middleware (\`key-manager/internal/api/middleware.go\`) already parses the forwarded JWT without re-validating (gateway has done that), so no code change is required.

## References
- NebariApp CRD: [reconcilers.nebari.dev_nebariapps.yaml](https://github.com/nebari-dev/nebari-operator/blob/main/config/crd/bases/reconcilers.nebari.dev_nebariapps.yaml) - schema includes \`spec.landingPage\` (displayName/description/category/icon/priority) and \`spec.gateway\` enum (public/internal).
- Landing page tile discovery is handled by nebari-landing's webapi, which lists NebariApps cluster-wide.

## Test plan
- [x] \`helm template\` renders the NebariApp with expected name/namespace/service/auth/landingPage blocks.
- [x] Omitting \`keyManager.nebariApp.hostname\` fails with \"keyManager.nebariApp.hostname is required when keyManager.nebariApp.enabled=true\".
- [x] Setting \`keyManager.nebariApp.enabled=false\` skips the template entirely.
- [x] \`helm lint\` clean.
- [ ] Install on a Nebari cluster: confirm HTTPRoute gets created, TLS cert issued, tile appears on the landing page, clicking it prompts Keycloak login, UI loads and API calls succeed.