### PR TITLE
Enforce model group access on internal JWT endpoint

### DIFF
--- a/operator/internal/controller/reconcilers/auth.go
+++ b/operator/internal/controller/reconcilers/auth.go
@@ -173,6 +173,29 @@ func buildInternalSecurityPolicy(model *llmv1alpha1.LLMModel, cfg *config.Operat
 		provider["audiences"] = []interface{}{cfg.OIDCAudience}
 	}
 
+	spec := map[string]interface{}{
+		"targetRefs": []interface{}{
+			map[string]interface{}{
+				"group": "gateway.networking.k8s.io",
+				"kind":  "HTTPRoute",
+				"name":  model.Name + "-internal",
+			},
+		},
+		"jwt": map[string]interface{}{
+			"providers": []interface{}{
+				provider,
+			},
+		},
+	}
+
+	// When the model is not public, add an authorization block that requires
+	// the JWT's groups claim to contain at least one of the model's allowed
+	// groups. The webhook rejects CRs where Public is false and Groups is
+	// empty, so we never render an Allow rule with no values.
+	if !isPublic(model) {
+		spec["authorization"] = buildGroupAuthorization(model.Spec.Access.Groups, cfg.OIDCGroupsClaim)
+	}
+
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "gateway.envoyproxy.io/v1alpha1",
@@ -182,17 +205,40 @@ func buildInternalSecurityPolicy(model *llmv1alpha1.LLMModel, cfg *config.Operat
 				"namespace": model.Namespace,
 				"labels":    labelsToInterface(StandardLabels(model)),
 			},
-			"spec": map[string]interface{}{
-				"targetRefs": []interface{}{
-					map[string]interface{}{
-						"group": "gateway.networking.k8s.io",
-						"kind":  "HTTPRoute",
-						"name":  model.Name + "-internal",
-					},
-				},
-				"jwt": map[string]interface{}{
-					"providers": []interface{}{
-						provider,
+			"spec": spec,
+		},
+	}
+}
+
+// isPublic returns true when the model's access policy is explicitly public.
+func isPublic(model *llmv1alpha1.LLMModel) bool {
+	return model.Spec.Access.Public != nil && *model.Spec.Access.Public
+}
+
+// buildGroupAuthorization returns an Envoy Gateway Authorization config that
+// allows requests whose JWT groups claim contains one of the listed groups and
+// denies everything else by default.
+func buildGroupAuthorization(groups []string, groupsClaim string) map[string]interface{} {
+	values := make([]interface{}, 0, len(groups))
+	for _, g := range groups {
+		values = append(values, g)
+	}
+	return map[string]interface{}{
+		"defaultAction": "Deny",
+		"rules": []interface{}{
+			map[string]interface{}{
+				"name":   "allow-groups",
+				"action": "Allow",
+				"principal": map[string]interface{}{
+					"jwt": map[string]interface{}{
+						"provider": "oidc",
+						"claims": []interface{}{
+							map[string]interface{}{
+								"name":      groupsClaim,
+								"valueType": "StringArray",
+								"values":    values,
+							},
+						},
 					},
 				},
 			},

--- a/operator/internal/controller/reconcilers/auth_test.go
+++ b/operator/internal/controller/reconcilers/auth_test.go
@@ -27,6 +27,12 @@ func defaultAuthModel() *llmv1alpha1.LLMModel {
 				Name:   "mistralai/Mistral-7B-v0.1",
 				Source: llmv1alpha1.ModelSourceHuggingFace,
 			},
+			// Default to a non-public model with one group so the internal
+			// SecurityPolicy always has a valid authorization block; matches
+			// the invariant the webhook enforces at admission time.
+			Access: llmv1alpha1.AccessSpec{
+				Groups: []string{"data-scientists"},
+			},
 		},
 	}
 }
@@ -483,6 +489,104 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 				}
 				if !foundUsername {
 					t.Error("expected claimToHeaders entry for X-Auth-User -> preferred_username")
+				}
+			},
+		},
+		{
+			name: "Internal SecurityPolicy: authorization allows only model's groups when not public",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultAuthModel()
+				m.Spec.Access = llmv1alpha1.AccessSpec{
+					Groups: []string{"ml-team", "platform"},
+				}
+				return m
+			}(),
+			cfg: defaultAuthConfig(),
+			check: func(t *testing.T, result *AuthResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				spec := result.InternalSecurityPolicy.Object["spec"].(map[string]interface{})
+				authz, ok := spec["authorization"].(map[string]interface{})
+				if !ok {
+					t.Fatal("expected authorization block on internal SecurityPolicy")
+				}
+				if authz["defaultAction"] != "Deny" {
+					t.Errorf("expected defaultAction=Deny, got %v", authz["defaultAction"])
+				}
+				rules := authz["rules"].([]interface{})
+				if len(rules) != 1 {
+					t.Fatalf("expected 1 rule, got %d", len(rules))
+				}
+				rule := rules[0].(map[string]interface{})
+				if rule["action"] != "Allow" {
+					t.Errorf("expected action=Allow, got %v", rule["action"])
+				}
+				principal := rule["principal"].(map[string]interface{})
+				jwtP := principal["jwt"].(map[string]interface{})
+				if jwtP["provider"] != "oidc" {
+					t.Errorf("expected provider=oidc, got %v", jwtP["provider"])
+				}
+				claims := jwtP["claims"].([]interface{})
+				if len(claims) != 1 {
+					t.Fatalf("expected 1 claim matcher, got %d", len(claims))
+				}
+				claim := claims[0].(map[string]interface{})
+				if claim["name"] != "groups" {
+					t.Errorf("expected claim name=groups, got %v", claim["name"])
+				}
+				if claim["valueType"] != "StringArray" {
+					t.Errorf("expected valueType=StringArray, got %v", claim["valueType"])
+				}
+				values := claim["values"].([]interface{})
+				if len(values) != 2 || values[0] != "ml-team" || values[1] != "platform" {
+					t.Errorf("expected values=[ml-team platform], got %v", values)
+				}
+			},
+		},
+		{
+			name: "Internal SecurityPolicy: public model has no authorization block",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultAuthModel()
+				public := true
+				m.Spec.Access = llmv1alpha1.AccessSpec{Public: &public}
+				return m
+			}(),
+			cfg: defaultAuthConfig(),
+			check: func(t *testing.T, result *AuthResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				spec := result.InternalSecurityPolicy.Object["spec"].(map[string]interface{})
+				if _, found := spec["authorization"]; found {
+					t.Error("expected no authorization block for public model")
+				}
+			},
+		},
+		{
+			name: "Internal SecurityPolicy: authorization uses configured groups claim name",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultAuthModel()
+				m.Spec.Access = llmv1alpha1.AccessSpec{
+					Groups: []string{"ops"},
+				}
+				return m
+			}(),
+			cfg: func() *config.OperatorConfig {
+				c := defaultAuthConfig()
+				c.OIDCGroupsClaim = "realm_access.roles"
+				return c
+			}(),
+			check: func(t *testing.T, result *AuthResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				spec := result.InternalSecurityPolicy.Object["spec"].(map[string]interface{})
+				authz := spec["authorization"].(map[string]interface{})
+				rules := authz["rules"].([]interface{})
+				claim := rules[0].(map[string]interface{})["principal"].(map[string]interface{})["jwt"].(map[string]interface{})["claims"].([]interface{})[0].(map[string]interface{})
+				if claim["name"] != "realm_access.roles" {
+					t.Errorf("expected configured claim name, got %v", claim["name"])
 				}
 			},
 		},

--- a/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
+++ b/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
@@ -72,6 +72,10 @@ func (v *LLMModelCustomValidator) ValidateCreate(ctx context.Context, obj runtim
 		return nil, err
 	}
 
+	if err := validateAccess(llmmodel); err != nil {
+		return nil, err
+	}
+
 	subdomain, err := effectiveSubdomain(llmmodel)
 	if err != nil {
 		return nil, err
@@ -98,6 +102,10 @@ func (v *LLMModelCustomValidator) ValidateUpdate(ctx context.Context, oldObj, ne
 		return nil, err
 	}
 
+	if err := validateAccess(llmmodel); err != nil {
+		return nil, err
+	}
+
 	subdomain, err := effectiveSubdomain(llmmodel)
 	if err != nil {
 		return nil, err
@@ -111,6 +119,25 @@ func (v *LLMModelCustomValidator) ValidateUpdate(ctx context.Context, oldObj, ne
 	warnings := emptyDirPreloadWarnings(llmmodel)
 
 	return warnings, nil
+}
+
+// validateAccess ensures the model explicitly declares who may call it: either
+// Access.Public=true or a non-empty Access.Groups list. A model with neither
+// would have no one able to call its internal JWT endpoint (the SecurityPolicy
+// would default-deny) and no groups to gate external API-key minting against,
+// so the ambiguous state is rejected at admission time.
+func validateAccess(llmmodel *llmv1alpha1.LLMModel) error {
+	public := llmmodel.Spec.Access.Public != nil && *llmmodel.Spec.Access.Public
+	if public {
+		return nil
+	}
+	if len(llmmodel.Spec.Access.Groups) == 0 {
+		return fmt.Errorf(
+			"spec.access must declare either public=true or at least one group in groups; " +
+				"a model with neither cannot be accessed by any user",
+		)
+	}
+	return nil
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type LLMModel.

--- a/operator/internal/webhook/v1alpha1/llmmodel_webhook_test.go
+++ b/operator/internal/webhook/v1alpha1/llmmodel_webhook_test.go
@@ -91,6 +91,30 @@ var _ = Describe("LLMModel Webhook", func() {
 			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, model) })
 		})
 
+		It("should reject a LLMModel with no public flag and no groups", func() {
+			ns := newManagedNamespace("test-managed-empty-access")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			model := newBaseLLMModel("my-model-empty-access", ns.Name)
+			model.Spec.Access = llmv1alpha1.AccessSpec{} // neither Public nor Groups
+			err := k8sClient.Create(bgCtx, model)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.access"))
+		})
+
+		It("should accept a LLMModel with Access.Public=true and no groups", func() {
+			ns := newManagedNamespace("test-managed-public")
+			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, ns) })
+
+			model := newBaseLLMModel("my-model-public", ns.Name)
+			public := true
+			model.Spec.Access = llmv1alpha1.AccessSpec{Public: &public}
+			Expect(k8sClient.Create(bgCtx, model)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(bgCtx, model) })
+		})
+
 		It("should reject a LLMModel in a namespace without the managed label", func() {
 			ns := newUnmanagedNamespace("test-unmanaged-create")
 			Expect(k8sClient.Create(bgCtx, ns)).To(Succeed())


### PR DESCRIPTION
## Summary
- Internal routes validated JWT signature/issuer but not which model the caller was authorized for, so any authenticated Keycloak user could reach any internal model endpoint regardless of \`spec.access.groups\`. Closes this gap.
- \`buildInternalSecurityPolicy\` now emits an Envoy Gateway \`authorization\` block when the model is not public: \`defaultAction: Deny\` + one \`Allow\` rule whose \`principal.jwt.claims\` matches the configured groups claim against \`spec.access.groups\` as a \`StringArray\`. Public models skip the block so any authenticated user is allowed.
- Webhook now rejects CRs where \`Access.Public\` is not \`true\` and \`Access.Groups\` is empty, producing a clear admission-time error instead of a delayed SecurityPolicy failure (EG requires \`MinItems=1\` on claim values anyway).

## References
- [Envoy Gateway SecurityPolicy authorization](https://github.com/envoyproxy/gateway/blob/v1.3.0/api/v1alpha1/authorization_types.go) - confirms \`JWTPrincipal.claims\` with \`valueType: StringArray\` is supported in v1.3.0 (our tested minimum).
- [JWTClaim schema](https://github.com/envoyproxy/gateway/blob/main/api/v1alpha1/authorization_types.go) - \`{name, valueType, values}\` shape and matching semantics.

## DoD mapping
Addresses items 4 and 5 of the project's definition of done for the internal path:
- (4) internal routes accessible to authorized users without further interaction beyond having a valid Keycloak JWT.
- (5) model CRD defines which Keycloak groups may access the model, now enforced at the gateway for the internal path (external API-key path was already gated at the UI and audit loop).

## Test plan
- [x] \`go test ./...\` in \`operator/\` - all green (reconcilers + webhook envtest).
- [x] New table cases: non-public with groups emits the expected authorization block, public model has no authorization block, configured groups claim name flows through.
- [x] New webhook cases: empty Access rejected, \`Public: true\` with no groups accepted.
- [x] \`golangci-lint run\` clean on touched packages.
- [ ] Deploy on a cluster with a model scoped to a Keycloak group; confirm a user outside the group gets a 403 from the internal endpoint while a user inside the group succeeds.