### PR TITLE
Clarify that the API key audit lookup is stubbed

### DIFF
--- a/charts/nebari-llm-serving/values.yaml
+++ b/charts/nebari-llm-serving/values.yaml
@@ -35,6 +35,12 @@ keyManager:
     tag: latest
     pullPolicy: Always
   auditInterval: 5m
+  # oidcUserinfoURL is currently non-functional and only exists to gate the
+  # audit loop on/off. The lookup it drives is stubbed out (see #55 for the
+  # Keycloak admin implementation); setting this URL will cause the auditor
+  # to log a lookup failure for every key and skip revocation rather than
+  # delete keys it cannot verify. Leave empty to keep the audit loop
+  # disabled entirely until #55 lands.
   oidcUserinfoURL: ""
 
 operator:

--- a/docs/design.md
+++ b/docs/design.md
@@ -231,13 +231,11 @@ This is a hard RBAC boundary. The key manager can only access Secrets in the ded
 
 ### API key audit
 
-The key manager runs a periodic background audit (configurable interval, default 5 minutes) that:
+The key manager includes a periodic background audit (configurable interval, default 5 minutes) that walks every API key Secret in `llm-api-keys`, looks up each creator's current groups, and revokes keys whose creator no longer belongs to a group in the model's `access.groups`.
 
-1. Lists all API key Secrets in `llm-api-keys`
-2. For each key entry, looks up the creator's current groups via the OIDC userinfo endpoint
-3. If the creator no longer belongs to a group that matches the model's `access.groups`, revokes the key
+**Current state:** the audit framework is wired up but the user-groups lookup is stubbed. Calling the OIDC `/userinfo` endpoint only works for the token bearer, and the auditor has a username rather than a user token, so it cannot be used as-is. Until this is replaced with a Keycloak admin lookup (tracked in #55), external API keys are **not** automatically revoked when a user loses group membership. The audit loop returns an error from the lookup and fails safe (skips revocation) rather than deleting keys it cannot verify.
 
-There is a window (up to the audit interval) where a user who has lost group access can still use existing keys. This is acceptable for v0.1 and consistent with how most RBAC systems handle eventual consistency.
+Operator-visible consequence: if a user is removed from a model's allowed groups, their JWT-based access to the internal endpoint is denied on the next request (the gateway checks `spec.access.groups` per request), but any external API keys they previously minted keep working until an admin deletes them manually or the LLMModel is deleted. Plan for this when designing group membership changes - or disable the external endpoint for models that need stricter revocation.
 
 ### Resource creation approach
 

--- a/key-manager/cmd/main.go
+++ b/key-manager/cmd/main.go
@@ -160,16 +160,19 @@ func getEnvOrDefault(key, defaultVal string) string {
 	return defaultVal
 }
 
-// makeUserinfoLookup returns a UserGroupsLookup that calls the OIDC userinfo endpoint.
-// For v0.1 this is a stub that returns an error so the auditor skips revocation
-// safely until token exchange is implemented.
+// makeUserinfoLookup returns a UserGroupsLookup for the audit loop.
+//
+// This is currently a stub: OIDC /userinfo only returns claims for the token
+// bearer, and the auditor has a username rather than a user token, so the
+// userinfo endpoint is not usable as-is. The lookup returns an error so the
+// auditor fails safe (skips revocation) rather than deleting keys it cannot
+// verify.
+//
+// The real implementation calls the Keycloak admin API with a service-account
+// token; tracked in
+// https://github.com/nebari-dev/nebari-llm-serving-pack/issues/55.
 func makeUserinfoLookup(userinfoURL string) audit.UserGroupsLookup {
 	return func(ctx context.Context, username string) ([]string, error) {
-		// TODO: Implement OIDC userinfo lookup.
-		// This requires either:
-		//   1. A service account token that can query the Keycloak admin API.
-		//   2. Token exchange to obtain a token for the user.
-		// Returning an error causes the auditor to skip revocation (fail-safe).
 		return nil, fmt.Errorf("userinfo lookup not yet implemented (url: %s, user: %s)", userinfoURL, username)
 	}
 }


### PR DESCRIPTION
## Summary
- \`docs/design.md\` §\"API key audit\" described the audit as fully functional. It isn't: the user-groups lookup is a stub and setting \`LLM_OIDC_USERINFO_URL\` just makes the auditor log a lookup error for every key and fail-safe (skip revocation).
- Rewrite that section to describe the current state honestly, note the operator-visible consequence (internal JWT access is denied per-request, external API keys keep working until manually revoked), and point at #55.
- Add the same caveat to the \`keyManager.oidcUserinfoURL\` values.yaml comment.
- Replace the inline TODO in \`makeUserinfoLookup\` with a link to #55.

No behavior change. Pair with #55 for the implementation.

## Test plan
- [x] \`go build ./...\` clean.
- [x] \`helm template\` clean against the current chart.