### PR TITLE
fix(#59): collapse pack into a single namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ apiVersion: llm.nebari.dev/v1alpha1
 kind: LLMModel
 metadata:
   name: qwen3-5-35b-a3b-gptq-int4
-  namespace: llm-serving
+  namespace: nebari-llm-serving-system
 spec:
   model:
     name: "Qwen/Qwen3.5-35B-A3B-GPTQ-Int4"
@@ -167,7 +167,7 @@ import os
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="http://qwen3-5-35b-a3b-gptq-int4.llm-serving.svc.cluster.local/v1",
+    base_url="http://qwen3-5-35b-a3b-gptq-int4.nebari-llm-serving-system.svc.cluster.local/v1",
     api_key=os.environ["JUPYTERHUB_API_TOKEN"],  # JWT from Nebari
 )
 response = client.chat.completions.create(
@@ -192,7 +192,6 @@ response = client.chat.completions.create(
 | `defaults.storage.storageClassName` | Default StorageClass for model PVCs (empty = cluster default) | `""` |
 | `defaults.monitoring.enabled` | Enable PodMonitor for Prometheus scraping | `true` |
 | `keyManager.enabled` | Deploy the key manager web UI | `true` |
-| `apiKeysNamespace` | Namespace where API key Secrets are stored | `llm-api-keys` |
 
 ## Architecture
 

--- a/charts/nebari-llm-serving/templates/api-keys-namespace.yaml
+++ b/charts/nebari-llm-serving/templates/api-keys-namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.apiKeysNamespace }}
-  labels:
-    {{- include "nebari-llm-serving.labels" . | nindent 4 }}

--- a/charts/nebari-llm-serving/templates/key-manager-deployment.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-deployment.yaml
@@ -26,8 +26,14 @@ spec:
             - containerPort: 8080
               name: http
           env:
+            # Per #59 the API-key Secrets live in the operator's own
+            # namespace alongside the LLMModels and SecurityPolicies that
+            # reference them. Use the downward API to pick that up rather
+            # than hardcoding it.
             - name: LLM_API_KEYS_NAMESPACE
-              value: {{ .Values.apiKeysNamespace | quote }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: LLM_OIDC_GROUPS_CLAIM
               value: {{ .Values.auth.oidc.groupsClaim | quote }}
             - name: LLM_AUTH_COOKIE_PREFIX

--- a/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
@@ -12,6 +12,15 @@ spec:
   service:
     name: {{ include "nebari-llm-serving.fullname" . }}-key-manager
     port: 8080
+  {{- with .Values.keyManager.nebariApp.routing }}
+  # routing is passed through verbatim from values so consumers can set
+  # routes / publicRoutes / tls / annotations without further chart edits.
+  # Required if you want the nebari-operator to provision an HTTPRoute and
+  # cert-manager Certificate for the key-manager hostname; without it the
+  # operator marks RoutingReady=False and skips both.
+  routing:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   auth:
     enabled: true
     provider: keycloak

--- a/charts/nebari-llm-serving/templates/key-manager-role.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-role.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.keyManager.enabled }}
+# Per #59 the API-key Secrets and metadata ConfigMaps live in the operator
+# namespace (alongside the LLMModel CRs and SecurityPolicies that reference
+# them). The key-manager only needs RBAC on its own namespace, no longer a
+# separate api-keys namespace.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "nebari-llm-serving.fullname" . }}-key-manager
-  namespace: {{ .Values.apiKeysNamespace }}
+  namespace: {{ include "nebari-llm-serving.operatorNamespace" . }}
   labels:
     {{- include "nebari-llm-serving.labels" . | nindent 4 }}
 rules:

--- a/charts/nebari-llm-serving/templates/key-manager-rolebinding.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-rolebinding.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "nebari-llm-serving.fullname" . }}-key-manager
-  namespace: {{ .Values.apiKeysNamespace }}
+  namespace: {{ include "nebari-llm-serving.operatorNamespace" . }}
   labels:
     {{- include "nebari-llm-serving.labels" . | nindent 4 }}
 roleRef:

--- a/charts/nebari-llm-serving/templates/namespace.yaml
+++ b/charts/nebari-llm-serving/templates/namespace.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.createNamespace -}}
+# Operator namespace.
+#
+# The validating webhook on LLMModel rejects any CR whose namespace lacks
+# `nebari.dev/managed=true`, and post-#59 also rejects any CR not in the
+# operator's own namespace. So the operator namespace must carry that
+# label or the chart bricks the pack on first install.
+#
+# `helm install --create-namespace` builds the namespace WITHOUT the
+# label. This template fills the gap. Set createNamespace=false if you
+# already manage the namespace yourself (e.g. via ArgoCD's
+# managedNamespaceMetadata, or a Terraform module) and have applied the
+# label there.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "nebari-llm-serving.operatorNamespace" . }}
+  labels:
+    {{- include "nebari-llm-serving.labels" . | nindent 4 }}
+    nebari.dev/managed: "true"
+{{- end }}

--- a/charts/nebari-llm-serving/templates/operator-deployment.yaml
+++ b/charts/nebari-llm-serving/templates/operator-deployment.yaml
@@ -44,14 +44,18 @@ spec:
             {{- end }}
             - name: LLM_OIDC_GROUPS_CLAIM
               value: {{ .Values.auth.oidc.groupsClaim | quote }}
-            - name: LLM_API_KEYS_NAMESPACE
-              value: {{ .Values.apiKeysNamespace | quote }}
             - name: LLM_DEFAULT_SERVING_IMAGE
               value: {{ .Values.defaults.serving.image | quote }}
             - name: LLM_DEFAULT_STORAGE_CLASS_NAME
               value: {{ .Values.defaults.storage.storageClassName | quote }}
             - name: ENABLE_WEBHOOKS
               value: "true"
+            # POD_NAMESPACE feeds the validating webhook's same-namespace
+            # check on LLMModel CRs (#59).
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - containerPort: 9443
               name: webhook-server

--- a/charts/nebari-llm-serving/values.yaml
+++ b/charts/nebari-llm-serving/values.yaml
@@ -1,3 +1,10 @@
+# createNamespace controls whether the chart provisions the operator's own
+# namespace and labels it `nebari.dev/managed=true` (required by the
+# validating webhook). Set to false when something else owns the namespace
+# - e.g. ArgoCD's managedNamespaceMetadata, a Terraform module, or
+# `helm install --create-namespace` followed by your own labelling.
+createNamespace: true
+
 platform:
   # baseDomain is REQUIRED - the base domain for the Nebari deployment
   baseDomain: ""

--- a/charts/nebari-llm-serving/values.yaml
+++ b/charts/nebari-llm-serving/values.yaml
@@ -75,8 +75,6 @@ operator:
     tag: latest
     pullPolicy: Always
 
-# Namespace where API keys (Secrets) are stored
-apiKeysNamespace: llm-api-keys
 
 defaults:
   serving:

--- a/dev/manifests/key-manager.yaml
+++ b/dev/manifests/key-manager.yaml
@@ -30,8 +30,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  # Per #59 the API-key Secrets and metadata ConfigMaps live in the
+  # operator's own namespace alongside the LLMModels and SecurityPolicies
+  # that reference them. The key-manager only needs RBAC on its own
+  # namespace.
   name: llm-key-manager
-  namespace: llm-api-keys
+  namespace: llm-operator-system
 rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps"]
@@ -41,7 +45,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: llm-key-manager
-  namespace: llm-api-keys
+  namespace: llm-operator-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -75,8 +79,12 @@ spec:
             - containerPort: 8080
               name: http
           env:
+            # Per #59 the API-key Secrets live in the operator's own
+            # namespace - use the downward API to pick that up.
             - name: LLM_API_KEYS_NAMESPACE
-              value: "llm-api-keys"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: LLM_OIDC_GROUPS_CLAIM
               value: "groups"
             - name: LLM_AUTH_COOKIE_PREFIX

--- a/dev/manifests/operator.yaml
+++ b/dev/manifests/operator.yaml
@@ -3,17 +3,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: llm-operator-system
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: llm-api-keys
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: llm-serving
   labels:
+    # Per #59 LLMModels live in the operator's own namespace, so this
+    # namespace also needs the managed label that the validating webhook
+    # checks for.
     nebari.dev/managed: "true"
 ---
 apiVersion: v1
@@ -115,10 +108,14 @@ spec:
               value: "https://keycloak.llm.local/realms/nebari"
             - name: LLM_OIDC_GROUPS_CLAIM
               value: "groups"
-            - name: LLM_API_KEYS_NAMESPACE
-              value: "llm-api-keys"
             - name: ENABLE_WEBHOOKS
               value: "true"
+            # POD_NAMESPACE feeds the webhook's same-namespace check on
+            # LLMModel CRs (#59).
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - containerPort: 9443
               name: webhook-server

--- a/dev/manifests/test-model.yaml
+++ b/dev/manifests/test-model.yaml
@@ -2,7 +2,7 @@ apiVersion: llm.nebari.dev/v1alpha1
 kind: LLMModel
 metadata:
   name: test-model
-  namespace: llm-serving
+  namespace: llm-operator-system  # per #59 LLMModels live in the operator namespace
 spec:
   model:
     name: "test/tiny-model"

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,8 +1,5 @@
 # Nebari LLM serving pack design
 
-> **Note (April 2026, [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59)):**
-> This document still describes the original "dedicated `llm-api-keys` namespace + ReferenceGrant" pattern. The actual implementation no longer matches that pattern. Envoy Gateway's `SecurityPolicy.spec.apiKeyAuth.credentialRefs` rejects cross-namespace Secret references and does not honor `ReferenceGrant` for that field, so the pack now keeps everything (LLMModel CRs, model pods, API-key Secrets, key-manager) in a single operator namespace, and a validating webhook enforces that LLMModel CRs are created there. The architecture sections below should be read with that change in mind; a full rewrite is pending.
-
 ## Overview
 
 A Nebari software pack for serving LLMs using llm-d with modelcar/OCI support for model distribution. The pack deploys a Go operator that watches a custom `LLMModel` CRD. Admins apply one LLMModel per model they want to serve. The operator handles everything downstream: model storage, vLLM serving pods, inference scheduling, routing, and access control.
@@ -44,7 +41,7 @@ apiVersion: llm.nebari.dev/v1alpha1
 kind: LLMModel
 metadata:
   name: devstral-32b
-  namespace: llm-serving
+  namespace: nebari-llm-serving-system
 spec:
   model:
     name: "mistralai/Devstral-Small-2505"
@@ -183,35 +180,37 @@ Changes to `model.revision` are treated as breaking changes that trigger a re-do
 ### Components deployed by the Helm chart (pack install)
 
 1. **LLMModel CRD** definition
-2. **LLM operator** - Go controller (kubebuilder/controller-runtime) watching LLMModel CRs
+2. **LLM operator** - Go controller (kubebuilder/controller-runtime) watching LLMModel CRs in its own namespace
 3. **Key manager** (conditional, `keyManager.enabled`) - web UI + REST API behind a NebariApp with Keycloak/OIDC auth
 4. **Envoy AI Gateway** (conditional, `envoyAIGateway.install`) - controller and CRDs; when false, assumes pre-installed
-5. **`llm-api-keys` namespace** - dedicated namespace for API key Secrets, isolated from model namespaces
+
+The chart creates the operator namespace and labels it `nebari.dev/managed=true` (gated on `createNamespace: true`, default on). Per [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59) all per-model resources - including API-key Secrets - live in this same namespace.
 
 ### Resources created by the operator per LLMModel
 
-| Resource | Namespace | Purpose |
-|---|---|---|
-| PVC | model namespace | Model storage (HuggingFace source, pvc storage type) |
-| Deployment (vLLM) | model namespace | Model serving pods with init container for preloading |
-| Service | model namespace | ClusterIP for the vLLM pods |
-| ServiceAccount | model namespace | Pod identity |
-| NetworkPolicy | model namespace | Default-deny ingress, allow only Gateway + EPP + Prometheus |
-| InferencePool + EPP | model namespace | Intelligent inference scheduling |
-| AIGatewayRoute (external) | model namespace | External endpoint with token counting, rate limiting |
-| AIGatewayRoute (internal) | model namespace | Internal endpoint with token counting, rate limiting |
-| SecurityPolicy (external) | model namespace | apiKeyAuth with sanitize:true, referencing api-keys Secret via ReferenceGrant |
-| SecurityPolicy (internal) | model namespace | JWT validation with group claim matching against access.groups |
-| Secret (API keys) | `llm-api-keys` | Per-model API key store (created by operator, data managed by key manager) |
-| ConfigMap (key metadata) | `llm-api-keys` | Per-model metadata for API keys (creator, timestamp, description) |
-| ReferenceGrant | `llm-api-keys` | Allows SecurityPolicy in model namespace to reference Secret in llm-api-keys |
-| PodMonitor | model namespace | Prometheus metrics scraping (when monitoring enabled) |
+All resources live in the LLMModel's own namespace, which (per the validating webhook) is the operator's namespace.
+
+| Resource | Purpose |
+|---|---|
+| PVC | Model storage (HuggingFace source, pvc storage type) |
+| Deployment (vLLM) | Model serving pods with init container for preloading |
+| Service | ClusterIP for the vLLM pods |
+| ServiceAccount | Pod identity |
+| NetworkPolicy | Default-deny ingress, allow only Gateway + EPP + Prometheus |
+| InferencePool + EPP | Intelligent inference scheduling |
+| AIGatewayRoute (external) | External endpoint with token counting, rate limiting |
+| AIGatewayRoute (internal) | Internal endpoint with token counting, rate limiting |
+| SecurityPolicy (external) | apiKeyAuth referencing the per-model Secret in the same namespace |
+| SecurityPolicy (internal) | JWT validation with group claim matching against access.groups |
+| Secret (API keys) | Per-model API key store (created by operator, data managed by key manager) |
+| ConfigMap (key metadata) | Per-model metadata for API keys (creator, timestamp, description) |
+| PodMonitor | Prometheus metrics scraping (when monitoring enabled) |
 
 ### Resource ownership
 
-All operator-created resources in the model namespace have an ownerReference back to the LLMModel CR. Deleting the LLMModel garbage-collects these resources.
+All operator-created resources except the API-key Secret + ConfigMap have an ownerReference back to the LLMModel CR. Deleting the LLMModel garbage-collects them.
 
-Resources in the `llm-api-keys` namespace (API key Secret, metadata ConfigMap, ReferenceGrant) cannot use cross-namespace ownerReferences. Instead, the operator labels them with `llm.nebari.dev/model-name` and `llm.nebari.dev/model-namespace`, and a finalizer on the LLMModel ensures cleanup on deletion.
+The API-key Secret and metadata ConfigMap deliberately omit ownerReferences. Their lifetime should outlive a reapply of the LLMModel CR (so an admin can recreate the LLMModel without users losing their issued keys). Cleanup is handled by a finalizer on the LLMModel that removes both resources when the CR is being deleted.
 
 ### NetworkPolicy
 
@@ -227,16 +226,16 @@ This makes the Gateway the only path to the model, whether endpoints are enabled
 
 The key manager runs with a dedicated ServiceAccount. Its RBAC is scoped to two areas:
 
-- **ClusterRole** for LLMModel read access: `get`, `list`, `watch` on `llmmodels.llm.nebari.dev` across all namespaces
-- **Role in `llm-api-keys` namespace**: `get`, `list`, `create`, `update`, `patch`, `delete` on Secrets and ConfigMaps in the `llm-api-keys` namespace only
+- **ClusterRole** for LLMModel read access: `get`, `list`, `watch` on `llmmodels.llm.nebari.dev` across all namespaces (broader than strictly needed today; see #59 follow-ups for tightening to a Role in the operator namespace)
+- **Role in the operator namespace**: `get`, `list`, `create`, `update`, `patch`, `delete` on Secrets and ConfigMaps in the operator namespace only
 
-This is a hard RBAC boundary. The key manager can only access Secrets in the dedicated `llm-api-keys` namespace, not in model namespaces or anywhere else. Kubernetes RBAC does not support label-based filtering, so namespace isolation is the enforcement mechanism.
+The key manager can only access Secrets in the operator namespace, not anywhere else. Per [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59) the API-key Secrets live in this same namespace, so this Role grants exactly the access the key manager needs and nothing more.
 
 ### API key audit
 
 The key manager runs a periodic background audit (configurable interval, default 5 minutes) that:
 
-1. Lists all API key Secrets in `llm-api-keys`
+1. Lists all API key Secrets in the operator namespace
 2. For each key entry, looks up the creator's current groups via the OIDC userinfo endpoint
 3. If the creator no longer belongs to a group that matches the model's `access.groups`, revokes the key
 
@@ -253,13 +252,12 @@ The tradeoff is tracking upstream changes manually. Each resource template in th
 ```
 LLMModel CR applied
   |
-  +-> Validate (webhook: subdomain uniqueness, DNS length, namespace label)
+  +-> Validate (webhook: subdomain uniqueness, DNS length, namespace label, same-as-operator-namespace)
   |
   +-> Phase: Pending
   |
   +-> Create PVC (if HF source + PVC storage type)
-  +-> Create API key Secret + metadata ConfigMap in llm-api-keys namespace
-  +-> Create ReferenceGrant in llm-api-keys namespace
+  +-> Create API key Secret + metadata ConfigMap in the LLMModel's own namespace
   +-> Create NetworkPolicy
   |
   +-> Create vLLM Deployment with init container for model download
@@ -304,7 +302,7 @@ Client -> Authorization: Bearer sk-... -> Envoy AI Gateway -> apiKeyAuth Securit
 - SecurityPolicy with `apiKeyAuth` attached to the generated HTTPRoute (same name as AIGatewayRoute)
 - `sanitize: true` strips the API key before forwarding to vLLM
 - `forwardClientIDHeader: X-Client-ID` passes the authenticated client ID downstream for logging and GIE flow control
-- API key Secret referenced cross-namespace via ReferenceGrant from `llm-api-keys`
+- API key Secret referenced same-namespace from the SecurityPolicy (per [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59) - Envoy Gateway's APIKeyAuth does not honor cross-namespace credentialRefs)
 
 ### Internal endpoint
 
@@ -359,7 +357,7 @@ A small web application behind NebariApp that lets authenticated users generate 
 2. Keycloak/OIDC login via NebariApp auth
 3. Key manager watches all LLMModel CRs, filters to models where `access.groups` overlaps with the user's OIDC groups (or `access.public: true`)
 4. User sees only models they can access
-5. User creates a key for a model; key manager generates `sk-<random>`, writes the client ID and key value to that model's `<name>-api-keys` Secret in the `llm-api-keys` namespace, and writes metadata to the corresponding ConfigMap
+5. User creates a key for a model; key manager generates `sk-<random>`, writes the client ID and key value to that model's `<name>-api-keys` Secret in the operator namespace, and writes metadata to the corresponding ConfigMap
 6. Envoy Gateway's apiKeyAuth picks up the new Secret entry immediately
 
 Revocation: remove the entry from the Secret and its corresponding metadata from the ConfigMap. Immediate effect.
@@ -370,7 +368,7 @@ API keys are issued based on the user's groups at creation time. If a user later
 
 ### Data model
 
-No database. State is split across two Kubernetes resources per model, both in the `llm-api-keys` namespace:
+No database. State is split across two Kubernetes resources per model, both in the operator namespace (alongside the LLMModel CR and the SecurityPolicy that reads the Secret):
 
 - **Secret** (`<model-name>-api-keys`): contains only the data Envoy Gateway needs. Each entry: key = client ID (e.g., `user-chuck-1`), value = the API key. This Secret is the source of truth for authentication because Envoy Gateway's apiKeyAuth reads from it natively. Individual Secrets are limited to 1 MiB, which supports roughly a few thousand keys per model. This is a known scaling limit for v0.1.
 
@@ -521,11 +519,11 @@ spec:
         - values-prod.yaml
   destination:
     server: https://kubernetes.default.svc
-    namespace: llm-serving
+    namespace: nebari-llm-serving-system
 ```
 
-2. ArgoCD deploys the pack: CRD, operator, key manager, AI Gateway, `llm-api-keys` namespace
-3. Admin applies LLMModel CRs (directly or via a second ArgoCD Application for GitOps)
+2. ArgoCD deploys the pack: CRD, operator, key manager, AI Gateway. The chart also creates the operator namespace and labels it `nebari.dev/managed=true` (gated on `createNamespace: true`, default on).
+3. Admin applies LLMModel CRs in the operator namespace (directly or via a second ArgoCD Application for GitOps). Per [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59) the validating webhook rejects LLMModels created anywhere else.
 4. Operator reconciles each LLMModel through its phases
 5. Users access the key manager UI to generate API keys, or use their JWT for in-cluster access
 
@@ -537,7 +535,7 @@ apiVersion: llm.nebari.dev/v1alpha1
 kind: LLMModel
 metadata:
   name: devstral-32b
-  namespace: llm-serving
+  namespace: nebari-llm-serving-system
 spec:
   model:
     name: "mistralai/Devstral-Small-2505"
@@ -571,7 +569,7 @@ apiVersion: llm.nebari.dev/v1alpha1
 kind: LLMModel
 metadata:
   name: qwen3-235b
-  namespace: llm-serving
+  namespace: nebari-llm-serving-system
 spec:
   model:
     name: "Qwen/Qwen3-235B-A22B"
@@ -674,17 +672,23 @@ nebari-llm-serving-pack/
   docs/
 ```
 
-## Multi-namespace support
+## Single-namespace deployment model
 
-LLMModels can be deployed in any namespace with the `nebari.dev/managed=true` label. This enables team isolation: the data science team deploys models in `llm-data-science`, the engineering team in `llm-engineering`.
+Per [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59), all pack components - the operator, the key manager, the LLMModel CRs, the model pods, the API-key Secrets, and the Envoy Gateway SecurityPolicies that reference them - live in **a single namespace per pack install**. The validating webhook on LLMModel rejects CRs created in any other namespace.
 
-**Operator**: single instance deployed by the Helm chart, with a ClusterRole that watches LLMModel CRs across all namespaces with `nebari.dev/managed=true`. It creates resources in the same namespace as the LLMModel (except API key Secrets, which go to `llm-api-keys`). One LLMModel failing reconciliation does not block others - errors are isolated per CR.
+This restriction exists because Envoy Gateway's `SecurityPolicy.spec.apiKeyAuth.credentialRefs` rejects cross-namespace Secret references and does not honor `ReferenceGrant` for that field. Co-locating the Secret with the SecurityPolicy is the only way to make `apiKeyAuth` work today. The earlier multi-namespace design (one operator watching `llm-data-science`, `llm-engineering`, etc., with a dedicated `llm-api-keys` namespace bridged via ReferenceGrant) hit this wall and is no longer how the pack is laid out.
 
-**Key manager**: single instance with a ClusterRole for LLMModel read access and a Role scoped to the `llm-api-keys` namespace for Secret/ConfigMap management. A user who belongs to groups with access to models in multiple namespaces sees all of them in the UI, grouped by namespace.
+**Operator**: single instance deployed by the Helm chart. Watches LLMModel CRs across all namespaces (current ClusterRole scope) but the webhook only accepts CRs in the operator's own namespace, so in practice it only ever reconciles CRs there. Tightening the ClusterRole to a Role on the operator namespace is a follow-up; see #59 discussion.
 
-**API key isolation**: all API key Secrets live in the dedicated `llm-api-keys` namespace. This provides a hard RBAC boundary - the key manager's ServiceAccount can only access Secrets in this namespace, not in model namespaces. ReferenceGrants allow Envoy Gateway SecurityPolicies in model namespaces to reference these Secrets cross-namespace.
+**Key manager**: single instance, RBAC scoped to the operator namespace for Secret/ConfigMap management. The Secrets it manages live in the same namespace it does, so a same-namespace Role is sufficient.
 
-**Namespace creation**: the operator does not create model namespaces. Admins create namespaces and label them `nebari.dev/managed=true` before applying LLMModels. The `llm-api-keys` namespace is created by the Helm chart.
+**API-key Secrets**: live in the operator namespace alongside the SecurityPolicies that reference them. The `apiKeyAuth.credentialRefs` field on each model SecurityPolicy carries no `namespace` field (an explicit assertion in `auth_test.go`).
+
+**Per-team isolation**: achieved by running multiple pack installs (one per team's operator namespace), not by a single operator watching multiple namespaces. This is operationally heavier than the original design but matches the only path the upstream auth machinery supports.
+
+**Operator namespace setup**: the chart provisions the operator namespace and applies `nebari.dev/managed=true` (gated on `createNamespace: true`, default on). Set `createNamespace: false` if something else - ArgoCD `managedNamespaceMetadata`, a Terraform module - is responsible for creating and labelling the namespace.
+
+**POD_NAMESPACE**: the operator deployment injects `POD_NAMESPACE` from the downward API and passes it to the webhook setup. Empty `POD_NAMESPACE` puts the webhook in test mode and skips the same-namespace check (used by envtest, which doesn't run the operator inside a pod).
 
 ## Security model
 
@@ -692,7 +696,7 @@ LLMModels can be deployed in any namespace with the `nebari.dev/managed=true` la
 
 **Network isolation**: model pods have a default-deny NetworkPolicy. Traffic is only allowed from the Envoy Gateway data plane, the EPP, and Prometheus. Direct Service access is blocked for all in-cluster workloads.
 
-**Secret isolation**: API key Secrets are in a dedicated namespace with namespace-scoped RBAC. The key manager is the only non-operator component with access to these Secrets.
+**Secret isolation**: API key Secrets live in the operator namespace with namespace-scoped RBAC. The key manager and the operator are the only components with access to these Secrets - the operator creates them, the key manager reads/updates them. SecurityPolicies in the same namespace reference them via `apiKeyAuth.credentialRefs` without crossing namespace boundaries (which Envoy Gateway does not allow for that field; see [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59)).
 
 **Gateway as security boundary**: all model access (external and internal) flows through Envoy Gateway, where auth is enforced via SecurityPolicy. The external endpoint uses apiKeyAuth with `sanitize: true` (API keys are stripped before reaching vLLM). The internal endpoint uses JWT validation against the OIDC issuer's JWKS endpoint.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,5 +1,8 @@
 # Nebari LLM serving pack design
 
+> **Note (April 2026, [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59)):**
+> This document still describes the original "dedicated `llm-api-keys` namespace + ReferenceGrant" pattern. The actual implementation no longer matches that pattern. Envoy Gateway's `SecurityPolicy.spec.apiKeyAuth.credentialRefs` rejects cross-namespace Secret references and does not honor `ReferenceGrant` for that field, so the pack now keeps everything (LLMModel CRs, model pods, API-key Secrets, key-manager) in a single operator namespace, and a validating webhook enforces that LLMModel CRs are created there. The architecture sections below should be read with that change in mind; a full rewrite is pending.
+
 ## Overview
 
 A Nebari software pack for serving LLMs using llm-d with modelcar/OCI support for model distribution. The pack deploys a Go operator that watches a custom `LLMModel` CRD. Admins apply one LLMModel per model they want to serve. The operator handles everything downstream: model storage, vLLM serving pods, inference scheduling, routing, and access control.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,10 +145,10 @@ curl -s -X POST http://localhost:8080/api/v1/keys \
   -d '{"modelName": "test-model", "namespace": "llm-serving"}' | jq .
 ```
 
-The response includes the generated key. Keys are stored as Kubernetes Secrets in the `llm-api-keys` namespace:
+The response includes the generated key. Keys are stored as Kubernetes Secrets in the operator namespace (defaults to `llm-operator-system` for the dev cluster, `nebari-llm-serving-system` for the chart):
 
 ```bash
-kubectl -n llm-api-keys get secrets
+kubectl -n llm-operator-system get secrets -l llm.nebari.dev/model
 ```
 
 ## 9. Cleanup

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,14 +84,14 @@ Apply the test `LLMModel` resource, which uses the mock vLLM image:
 make apply-test-model
 ```
 
-This creates an `LLMModel` named `test-model` in the `llm-serving` namespace. The operator reconciles it and creates the supporting resources.
+This creates an `LLMModel` named `test-model` in the `llm-operator-system` namespace. The operator reconciles it and creates the supporting resources. (Per [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59) all LLMModels must live in the operator's own namespace - the validating webhook rejects anywhere else.)
 
 ## 6. Watch reconciliation
 
 Watch the `LLMModel` status update as the operator reconciles:
 
 ```bash
-kubectl -n llm-serving get llmmodels -w
+kubectl -n llm-operator-system get llmmodels -w
 ```
 
 You should see the `READY` column transition through states as each sub-resource is created. Once all reconcilers complete, the model shows `Ready`.
@@ -107,9 +107,9 @@ make logs-operator
 Once the model is ready, verify the created resources:
 
 ```bash
-kubectl -n llm-serving get all
-kubectl -n llm-serving get aigatewayroutes
-kubectl -n envoy-gateway-system get securitypolicies
+kubectl -n llm-operator-system get all
+kubectl -n llm-operator-system get aigatewayroutes
+kubectl -n llm-operator-system get securitypolicies
 ```
 
 The operator creates:
@@ -117,8 +117,7 @@ The operator creates:
 - A `Service` for the deployment
 - An `InferencePool` for intelligent request scheduling
 - `AIGatewayRoute` resources for external (API key) and internal (JWT) access
-- `SecurityPolicy` resources for auth enforcement
-- A `ReferenceGrant` to allow cross-namespace policy references
+- `SecurityPolicy` resources for auth enforcement (the API-key Secret they reference is co-located in this same namespace; see [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59) for why)
 
 ## 8. Test the key manager API
 
@@ -142,7 +141,7 @@ Create an API key for the test model:
 curl -s -X POST http://localhost:8080/api/v1/keys \
   -H "Authorization: Bearer fake-jwt-token" \
   -H "Content-Type: application/json" \
-  -d '{"modelName": "test-model", "namespace": "llm-serving"}' | jq .
+  -d '{"modelName": "test-model"}' | jq .
 ```
 
 The response includes the generated key. Keys are stored as Kubernetes Secrets in the operator namespace (defaults to `llm-operator-system` for the dev cluster, `nebari-llm-serving-system` for the chart):

--- a/examples/models/devstral-small.yaml
+++ b/examples/models/devstral-small.yaml
@@ -7,7 +7,7 @@ apiVersion: llm.nebari.dev/v1alpha1
 kind: LLMModel
 metadata:
   name: devstral-small
-  namespace: llm-serving
+  namespace: nebari-llm-serving-system  # LLMModel must live in the operator namespace (per #59); for the dev cluster use llm-operator-system
 spec:
   model:
     name: "mistralai/Devstral-Small-2505"

--- a/examples/models/oci-model.yaml
+++ b/examples/models/oci-model.yaml
@@ -5,7 +5,7 @@ apiVersion: llm.nebari.dev/v1alpha1
 kind: LLMModel
 metadata:
   name: my-oci-model
-  namespace: llm-serving
+  namespace: nebari-llm-serving-system  # LLMModel must live in the operator namespace (per #59); for the dev cluster use llm-operator-system
 spec:
   model:
     name: "my-org/my-model"

--- a/examples/models/qwen3-5-35b-a3b-gptq-int4.yaml
+++ b/examples/models/qwen3-5-35b-a3b-gptq-int4.yaml
@@ -4,7 +4,7 @@ apiVersion: llm.nebari.dev/v1alpha1
 kind: LLMModel
 metadata:
   name: qwen3-5-35b-a3b-gptq-int4
-  namespace: llm-serving
+  namespace: nebari-llm-serving-system  # LLMModel must live in the operator namespace (per #59); for the dev cluster use llm-operator-system
 spec:
   model:
     name: "Qwen/Qwen3.5-35B-A3B-GPTQ-Int4"

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -196,7 +196,13 @@ func main() {
 	}
 	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err := webhookv1alpha1.SetupLLMModelWebhookWithManager(mgr); err != nil {
+		// POD_NAMESPACE is injected via the downward API on the operator
+		// Deployment; the webhook uses it to enforce that LLMModels are
+		// created in the operator's namespace so their API-key Secrets land
+		// in the same namespace as the SecurityPolicies that reference them.
+		// See https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59.
+		operatorNamespace := os.Getenv("POD_NAMESPACE")
+		if err := webhookv1alpha1.SetupLLMModelWebhookWithManager(mgr, operatorNamespace); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "LLMModel")
 			os.Exit(1)
 		}

--- a/operator/internal/config/config.go
+++ b/operator/internal/config/config.go
@@ -35,7 +35,14 @@ type OperatorConfig struct {
 	OIDCAudience            string // LLM_OIDC_AUDIENCE (optional, empty string means no audience check)
 	DefaultServingImage     string // LLM_DEFAULT_SERVING_IMAGE (default: "ghcr.io/llm-d/llm-d-cuda:v0.6.0")
 	DefaultStorageClassName string // LLM_DEFAULT_STORAGE_CLASS_NAME (optional, empty = cluster default)
-	APIKeysNamespace        string // LLM_API_KEYS_NAMESPACE (default: "llm-api-keys")
+	// APIKeysNamespace is no longer used to PLACE Secrets - per #59 the
+	// API-key Secrets and metadata ConfigMaps now live in the LLMModel's
+	// own namespace so SecurityPolicy.apiKeyAuth.credentialRefs can
+	// reference them without a cross-namespace ref. This field is kept
+	// only so the finalizer can clean up legacy resources from clusters
+	// originally deployed against a separate api-keys namespace; new
+	// deployments leave it empty.
+	APIKeysNamespace string // LLM_API_KEYS_NAMESPACE (legacy cleanup hint, default empty)
 }
 
 // getEnvOrDefault returns the value of the environment variable named by key,
@@ -72,7 +79,7 @@ func LoadFromEnv() (*OperatorConfig, error) {
 		OIDCAudience:            os.Getenv("LLM_OIDC_AUDIENCE"),
 		DefaultServingImage:     getEnvOrDefault("LLM_DEFAULT_SERVING_IMAGE", "ghcr.io/llm-d/llm-d-cuda:v0.6.0"),
 		DefaultStorageClassName: os.Getenv("LLM_DEFAULT_STORAGE_CLASS_NAME"),
-		APIKeysNamespace:        getEnvOrDefault("LLM_API_KEYS_NAMESPACE", "llm-api-keys"),
+		APIKeysNamespace:        os.Getenv("LLM_API_KEYS_NAMESPACE"),
 	}
 
 	if len(missing) > 0 {

--- a/operator/internal/config/config_test.go
+++ b/operator/internal/config/config_test.go
@@ -116,7 +116,7 @@ func TestLoadFromEnv(t *testing.T) {
 				OIDCGroupsClaim:     "groups",
 				OIDCAudience:        "",
 				DefaultServingImage: "ghcr.io/llm-d/llm-d-cuda:v0.6.0",
-				APIKeysNamespace:    "llm-api-keys",
+				APIKeysNamespace:    "",
 			},
 		},
 		{
@@ -139,7 +139,7 @@ func TestLoadFromEnv(t *testing.T) {
 				OIDCGroupsClaim:     "groups",
 				OIDCAudience:        "",
 				DefaultServingImage: "ghcr.io/llm-d/llm-d-cuda:v0.6.0",
-				APIKeysNamespace:    "llm-api-keys",
+				APIKeysNamespace:    "",
 			},
 		},
 		{

--- a/operator/internal/controller/llmmodel_controller.go
+++ b/operator/internal/controller/llmmodel_controller.go
@@ -128,7 +128,7 @@ func (r *LLMModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("building auth resources: %w", err)
 		}
-		if err := r.reconcileAuthSecretAndConfigMap(ctx, log, authResources); err != nil {
+		if err := r.reconcileAuthSecretAndConfigMap(ctx, authResources); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -270,7 +270,6 @@ func (r *LLMModelReconciler) reconcileDelete(ctx context.Context, model *llmv1al
 // outlive a reapply of the LLMModel; cleanup is handled by the finalizer.
 func (r *LLMModelReconciler) reconcileAuthSecretAndConfigMap(
 	ctx context.Context,
-	log controllerLogger,
 	auth *reconcilers.AuthResources,
 ) error {
 	if err := r.createOrUpdateSecret(ctx, auth.APIKeySecret); err != nil {
@@ -279,7 +278,6 @@ func (r *LLMModelReconciler) reconcileAuthSecretAndConfigMap(
 	if err := r.createOrUpdateConfigMap(ctx, auth.APIKeyMetadataCM); err != nil {
 		return fmt.Errorf("reconciling api key metadata configmap: %w", err)
 	}
-	_ = log
 	return nil
 }
 

--- a/operator/internal/controller/llmmodel_controller.go
+++ b/operator/internal/controller/llmmodel_controller.go
@@ -27,7 +27,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -103,14 +102,7 @@ func (r *LLMModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	// 5. Ensure the llm-api-keys namespace exists (if Config is available)
-	if r.Config != nil {
-		if err := r.ensureNamespace(ctx, r.Config.APIKeysNamespace); err != nil {
-			return ctrl.Result{}, fmt.Errorf("ensuring api-keys namespace: %w", err)
-		}
-	}
-
-	// 6. Reconcile storage (PVC)
+	// 5. Reconcile storage (PVC)
 	defaultStorageClass := ""
 	if r.Config != nil {
 		defaultStorageClass = r.Config.DefaultStorageClassName
@@ -129,14 +121,14 @@ func (r *LLMModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	// 7. Reconcile auth resources (cross-namespace: Secret, ConfigMap, ReferenceGrant)
+	// 6. Reconcile auth resources (Secret + ConfigMap, both in the model's namespace)
 	var authResources *reconcilers.AuthResources
 	if r.Config != nil {
 		authResources, err = reconcilers.BuildAuthResources(model, r.Config)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("building auth resources: %w", err)
 		}
-		if err := r.reconcileCrossNamespaceResources(ctx, log, authResources); err != nil {
+		if err := r.reconcileAuthSecretAndConfigMap(ctx, log, authResources); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -213,34 +205,37 @@ func (r *LLMModelReconciler) reconcileDelete(ctx context.Context, model *llmv1al
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("cleaning up cross-namespace resources", "model", model.Name)
+	log.Info("cleaning up auth resources", "model", model.Name)
 
-	if r.Config != nil {
-		// Delete Secret in api-keys namespace
-		secret := &corev1.Secret{}
-		secretKey := types.NamespacedName{
-			Name:      reconcilers.APIKeySecretName(model.Name),
-			Namespace: r.Config.APIKeysNamespace,
+	// Delete API-key Secret in the model's namespace.
+	secret := &corev1.Secret{}
+	secretKey := types.NamespacedName{
+		Name:      reconcilers.APIKeySecretName(model.Name),
+		Namespace: model.Namespace,
+	}
+	if err := r.Get(ctx, secretKey, secret); err == nil {
+		if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("deleting api key secret: %w", err)
 		}
-		if err := r.Get(ctx, secretKey, secret); err == nil {
-			if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("deleting api key secret: %w", err)
-			}
-		}
+	}
 
-		// Delete ConfigMap in api-keys namespace
-		cm := &corev1.ConfigMap{}
-		cmKey := types.NamespacedName{
-			Name:      reconcilers.APIKeyMetadataConfigMapName(model.Name),
-			Namespace: r.Config.APIKeysNamespace,
+	// Delete metadata ConfigMap in the model's namespace.
+	cm := &corev1.ConfigMap{}
+	cmKey := types.NamespacedName{
+		Name:      reconcilers.APIKeyMetadataConfigMapName(model.Name),
+		Namespace: model.Namespace,
+	}
+	if err := r.Get(ctx, cmKey, cm); err == nil {
+		if err := r.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("deleting api key metadata configmap: %w", err)
 		}
-		if err := r.Get(ctx, cmKey, cm); err == nil {
-			if err := r.Delete(ctx, cm); err != nil && !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("deleting api key metadata configmap: %w", err)
-			}
-		}
+	}
 
-		// Delete ReferenceGrant in api-keys namespace
+	// Pre-#59 deployments may have left a ReferenceGrant behind in the
+	// dedicated api-keys namespace. Best-effort cleanup of that legacy
+	// resource so the namespace can drain. Skip if the API-keys namespace
+	// concept isn't even configured anymore.
+	if r.Config != nil && r.Config.APIKeysNamespace != "" && r.Config.APIKeysNamespace != model.Namespace {
 		refGrant := &unstructured.Unstructured{}
 		refGrant.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   "gateway.networking.k8s.io",
@@ -253,8 +248,7 @@ func (r *LLMModelReconciler) reconcileDelete(ctx context.Context, model *llmv1al
 		}
 		if err := r.Get(ctx, refGrantKey, refGrant); err == nil {
 			if err := r.Delete(ctx, refGrant); err != nil && !apierrors.IsNotFound(err) {
-				// Non-fatal: CRD may not be installed
-				log.Error(err, "failed to delete ReferenceGrant during cleanup")
+				log.Error(err, "failed to delete legacy ReferenceGrant during cleanup")
 			}
 		}
 	}
@@ -268,27 +262,13 @@ func (r *LLMModelReconciler) reconcileDelete(ctx context.Context, model *llmv1al
 	return ctrl.Result{}, nil
 }
 
-// ensureNamespace creates the namespace if it does not exist.
-func (r *LLMModelReconciler) ensureNamespace(ctx context.Context, name string) error {
-	ns := &corev1.Namespace{}
-	if err := r.Get(ctx, types.NamespacedName{Name: name}, ns); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
-		}
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-		}
-		if err := r.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-// reconcileCrossNamespaceResources creates or updates the Secret, ConfigMap, and
-// ReferenceGrant in the api-keys namespace. These resources have no owner references
-// and are cleaned up by the finalizer.
-func (r *LLMModelReconciler) reconcileCrossNamespaceResources(
+// reconcileAuthSecretAndConfigMap creates or updates the API-key Secret and
+// metadata ConfigMap. Both live in the LLMModel's own namespace (no longer in
+// a separate api-keys namespace) so the SecurityPolicy can reference them
+// without a cross-namespace credentialRef. These resources have no owner
+// references because they hold user-issued API keys whose lifetime should
+// outlive a reapply of the LLMModel; cleanup is handled by the finalizer.
+func (r *LLMModelReconciler) reconcileAuthSecretAndConfigMap(
 	ctx context.Context,
 	log controllerLogger,
 	auth *reconcilers.AuthResources,
@@ -299,11 +279,7 @@ func (r *LLMModelReconciler) reconcileCrossNamespaceResources(
 	if err := r.createOrUpdateConfigMap(ctx, auth.APIKeyMetadataCM); err != nil {
 		return fmt.Errorf("reconciling api key metadata configmap: %w", err)
 	}
-	if auth.ReferenceGrant != nil {
-		if err := r.createOrUpdateUnstructured(ctx, auth.ReferenceGrant); err != nil {
-			log.Error(err, "failed to reconcile ReferenceGrant - CRD may not be installed, skipping")
-		}
-	}
+	_ = log
 	return nil
 }
 

--- a/operator/internal/controller/llmmodel_controller_test.go
+++ b/operator/internal/controller/llmmodel_controller_test.go
@@ -48,7 +48,11 @@ func testConfig() *config.OperatorConfig {
 		OIDCGroupsClaim:     "groups",
 		OIDCAudience:        "",
 		DefaultServingImage: "ghcr.io/llm-d/llm-d-cuda:v0.6.0",
-		APIKeysNamespace:    "llm-api-keys-test",
+		// Empty matches the post-#59 default. The legacy ReferenceGrant
+		// cleanup branch in reconcileDelete checks for non-empty, so
+		// leaving it empty disables that branch (which is what new
+		// installs want). A separate fixture covers the legacy path.
+		APIKeysNamespace: "",
 	}
 }
 

--- a/operator/internal/controller/llmmodel_controller_test.go
+++ b/operator/internal/controller/llmmodel_controller_test.go
@@ -234,8 +234,8 @@ var _ = Describe("LLMModel Controller", func() {
 		})
 	})
 
-	Describe("Cross-namespace resources (llm-api-keys namespace)", func() {
-		const modelName = "test-cross-ns"
+	Describe("Auth resources (Secret + ConfigMap in the model's namespace)", func() {
+		const modelName = "test-auth-resources"
 
 		AfterEach(func() {
 			model := &llmv1alpha1.LLMModel{}
@@ -246,7 +246,7 @@ var _ = Describe("LLMModel Controller", func() {
 			}
 		})
 
-		It("creates Secret and ConfigMap in the api-keys namespace", func() {
+		It("creates Secret and ConfigMap in the model's own namespace", func() {
 			By("creating the LLMModel")
 			model := newMinimalModel(modelName)
 			Expect(k8sClient.Create(ctx, model)).To(Succeed())
@@ -256,34 +256,26 @@ var _ = Describe("LLMModel Controller", func() {
 			err := reconcileUntilStable(r, ctx, reconcileRequest(modelName))
 			Expect(err).NotTo(HaveOccurred())
 
-			apiKeysNS := testConfig().APIKeysNamespace
-
-			By("verifying the api-keys namespace was created")
-			ns := &corev1.Namespace{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: apiKeysNS}, ns)).To(Succeed())
-
-			By("verifying API key Secret exists in api-keys namespace")
+			By("verifying API key Secret exists in the model's namespace")
 			secret := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      modelName + "-api-keys",
-				Namespace: apiKeysNS,
+				Namespace: testNamespace,
 			}, secret)).To(Succeed())
-			Expect(secret.Labels["llm.nebari.dev/model-name"]).To(Equal(modelName))
 
-			By("verifying API key metadata ConfigMap exists in api-keys namespace")
+			By("verifying API key metadata ConfigMap exists in the model's namespace")
 			cm := &corev1.ConfigMap{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      modelName + "-api-key-metadata",
-				Namespace: apiKeysNS,
+				Namespace: testNamespace,
 			}, cm)).To(Succeed())
-			Expect(cm.Labels["llm.nebari.dev/model-name"]).To(Equal(modelName))
 		})
 	})
 
 	Describe("Deletion with finalizer cleanup", func() {
 		const modelName = "test-deletion"
 
-		It("cleans up cross-namespace resources on deletion", func() {
+		It("deletes the API-key Secret and ConfigMap on LLMModel deletion", func() {
 			By("creating the LLMModel")
 			model := newMinimalModel(modelName)
 			Expect(k8sClient.Create(ctx, model)).To(Succeed())
@@ -293,13 +285,11 @@ var _ = Describe("LLMModel Controller", func() {
 			err := reconcileUntilStable(r, ctx, reconcileRequest(modelName))
 			Expect(err).NotTo(HaveOccurred())
 
-			apiKeysNS := testConfig().APIKeysNamespace
-
-			By("verifying cross-namespace resources exist")
+			By("verifying auth resources exist in the model's namespace")
 			secret := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      modelName + "-api-keys",
-				Namespace: apiKeysNS,
+				Namespace: testNamespace,
 			}, secret)).To(Succeed())
 
 			By("deleting the LLMModel (triggers finalizer)")
@@ -311,19 +301,19 @@ var _ = Describe("LLMModel Controller", func() {
 			err = reconcileUntilStable(r, ctx, reconcileRequest(modelName))
 			Expect(err).NotTo(HaveOccurred())
 
-			By("verifying cross-namespace Secret was deleted")
+			By("verifying API-key Secret was deleted")
 			deletedSecret := &corev1.Secret{}
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      modelName + "-api-keys",
-				Namespace: apiKeysNS,
+				Namespace: testNamespace,
 			}, deletedSecret)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 
-			By("verifying cross-namespace ConfigMap was deleted")
+			By("verifying metadata ConfigMap was deleted")
 			deletedCM := &corev1.ConfigMap{}
 			err = k8sClient.Get(ctx, types.NamespacedName{
 				Name:      modelName + "-api-key-metadata",
-				Namespace: apiKeysNS,
+				Namespace: testNamespace,
 			}, deletedCM)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 

--- a/operator/internal/controller/reconcilers/auth.go
+++ b/operator/internal/controller/reconcilers/auth.go
@@ -9,29 +9,31 @@ import (
 	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
 )
 
-// AuthResources holds all auth-related resources for an LLMModel.
+// AuthResources holds all auth-related resources for an LLMModel. All
+// resources live in the LLMModel's own namespace - the operator no longer
+// uses a separate api-keys namespace because Envoy Gateway's
+// SecurityPolicy.spec.apiKeyAuth.credentialRefs rejects cross-namespace
+// Secret references (it does not honor ReferenceGrant for that field; see
+// nebari-dev/nebari-llm-serving-pack#59). The model webhook enforces that
+// LLMModel CRs live in the operator's namespace so that the key-manager
+// (also in the operator namespace) can find these Secrets.
 type AuthResources struct {
-	// Resources in the llm-api-keys namespace (no ownerReference, cleaned up via finalizer)
-	APIKeySecret     *corev1.Secret
-	APIKeyMetadataCM *corev1.ConfigMap
-	ReferenceGrant   *unstructured.Unstructured // gateway.networking.k8s.io/v1beta1 ReferenceGrant
-
-	// Resources in the model namespace
+	APIKeySecret           *corev1.Secret
+	APIKeyMetadataCM       *corev1.ConfigMap
 	ExternalSecurityPolicy *unstructured.Unstructured // apiKeyAuth SecurityPolicy, nil if external disabled
 	InternalSecurityPolicy *unstructured.Unstructured // JWT SecurityPolicy, nil if internal disabled
 }
 
 // BuildAuthResources is a pure function that computes all auth-related Kubernetes resources
-// for the given LLMModel: API key Secret, metadata ConfigMap, ReferenceGrant, and SecurityPolicies.
+// for the given LLMModel: API key Secret, metadata ConfigMap, and SecurityPolicies.
+// All resources are placed in the LLMModel's own namespace.
 func BuildAuthResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig) (*AuthResources, error) {
 	result := &AuthResources{}
 
-	// Shared labels for cross-namespace resources (Secret and ConfigMap in api-keys namespace)
-	crossNSLabels := buildCrossNSLabels(model)
+	labels := StandardLabels(model)
 
-	result.APIKeySecret = buildAPIKeySecret(model, cfg, crossNSLabels)
-	result.APIKeyMetadataCM = buildAPIKeyMetadataConfigMap(model, cfg, crossNSLabels)
-	result.ReferenceGrant = buildReferenceGrant(model, cfg)
+	result.APIKeySecret = buildAPIKeySecret(model, labels)
+	result.APIKeyMetadataCM = buildAPIKeyMetadataConfigMap(model, labels)
 
 	if boolOrDefault(model.Spec.Endpoints.External.Enabled, true) {
 		result.ExternalSecurityPolicy = buildExternalSecurityPolicy(model, cfg)
@@ -44,62 +46,23 @@ func BuildAuthResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig)
 	return result, nil
 }
 
-// buildCrossNSLabels returns labels for resources that live in the api-keys namespace
-// but belong to a specific model in another namespace.
-func buildCrossNSLabels(model *llmv1alpha1.LLMModel) map[string]string {
-	labels := StandardLabels(model)
-	labels["llm.nebari.dev/model-name"] = model.Name
-	labels["llm.nebari.dev/model-namespace"] = model.Namespace
-	return labels
-}
-
-func buildAPIKeySecret(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig, labels map[string]string) *corev1.Secret {
+func buildAPIKeySecret(model *llmv1alpha1.LLMModel, labels map[string]string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      APIKeySecretName(model.Name),
-			Namespace: cfg.APIKeysNamespace,
+			Namespace: model.Namespace,
 			Labels:    labels,
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
 }
 
-func buildAPIKeyMetadataConfigMap(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig, labels map[string]string) *corev1.ConfigMap {
+func buildAPIKeyMetadataConfigMap(model *llmv1alpha1.LLMModel, labels map[string]string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      APIKeyMetadataConfigMapName(model.Name),
-			Namespace: cfg.APIKeysNamespace,
+			Namespace: model.Namespace,
 			Labels:    labels,
-		},
-	}
-}
-
-func buildReferenceGrant(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig) *unstructured.Unstructured {
-	name := model.Name + "-" + model.Namespace + "-ref-grant"
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "gateway.networking.k8s.io/v1beta1",
-			"kind":       "ReferenceGrant",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": cfg.APIKeysNamespace,
-			},
-			"spec": map[string]interface{}{
-				"from": []interface{}{
-					map[string]interface{}{
-						"group":     "gateway.envoyproxy.io",
-						"kind":      "SecurityPolicy",
-						"namespace": model.Namespace,
-					},
-				},
-				"to": []interface{}{
-					map[string]interface{}{
-						"group": "",
-						"kind":  "Secret",
-						"name":  APIKeySecretName(model.Name),
-					},
-				},
-			},
 		},
 	}
 }
@@ -124,12 +87,15 @@ func buildExternalSecurityPolicy(model *llmv1alpha1.LLMModel, cfg *config.Operat
 					},
 				},
 				"apiKeyAuth": map[string]interface{}{
+					// No `namespace` field - Envoy Gateway's APIKeyAuth rejects
+					// any cross-namespace credentialRef (and does not honor
+					// ReferenceGrant for this field). The Secret lives in the
+					// same namespace as this SecurityPolicy by design.
 					"credentialRefs": []interface{}{
 						map[string]interface{}{
-							"group":     "",
-							"kind":      "Secret",
-							"name":      APIKeySecretName(model.Name),
-							"namespace": cfg.APIKeysNamespace,
+							"group": "",
+							"kind":  "Secret",
+							"name":  APIKeySecretName(model.Name),
 						},
 					},
 					"extractFrom": []interface{}{

--- a/operator/internal/controller/reconcilers/auth.go
+++ b/operator/internal/controller/reconcilers/auth.go
@@ -47,10 +47,13 @@ func BuildAuthResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig)
 }
 
 // authResourceLabels returns the labels applied to the API-key Secret and
-// metadata ConfigMap. The `llm.nebari.dev/model-name` label is the documented
-// selector for `kubectl get secrets -l llm.nebari.dev/model` (see
-// docs/getting-started.md). The `model-namespace` label was redundant once
-// these resources moved into the model's own namespace (#59) and was dropped.
+// metadata ConfigMap. The `llm.nebari.dev/model` label (from StandardLabels)
+// is the documented selector for `kubectl get secrets -l llm.nebari.dev/model`
+// (see docs/getting-started.md). The additional `llm.nebari.dev/model-name`
+// label is required by the key-manager, which filters API-key metadata
+// ConfigMaps on it (see key-manager/internal/secrets/manager.go). The
+// `model-namespace` label was redundant once these resources moved into the
+// model's own namespace (#59) and was dropped.
 func authResourceLabels(model *llmv1alpha1.LLMModel) map[string]string {
 	labels := StandardLabels(model)
 	labels["llm.nebari.dev/model-name"] = model.Name

--- a/operator/internal/controller/reconcilers/auth.go
+++ b/operator/internal/controller/reconcilers/auth.go
@@ -30,13 +30,13 @@ type AuthResources struct {
 func BuildAuthResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig) (*AuthResources, error) {
 	result := &AuthResources{}
 
-	labels := StandardLabels(model)
+	labels := authResourceLabels(model)
 
 	result.APIKeySecret = buildAPIKeySecret(model, labels)
 	result.APIKeyMetadataCM = buildAPIKeyMetadataConfigMap(model, labels)
 
 	if boolOrDefault(model.Spec.Endpoints.External.Enabled, true) {
-		result.ExternalSecurityPolicy = buildExternalSecurityPolicy(model, cfg)
+		result.ExternalSecurityPolicy = buildExternalSecurityPolicy(model)
 	}
 
 	if boolOrDefault(model.Spec.Endpoints.Internal.Enabled, true) {
@@ -44,6 +44,17 @@ func BuildAuthResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig)
 	}
 
 	return result, nil
+}
+
+// authResourceLabels returns the labels applied to the API-key Secret and
+// metadata ConfigMap. The `llm.nebari.dev/model-name` label is the documented
+// selector for `kubectl get secrets -l llm.nebari.dev/model` (see
+// docs/getting-started.md). The `model-namespace` label was redundant once
+// these resources moved into the model's own namespace (#59) and was dropped.
+func authResourceLabels(model *llmv1alpha1.LLMModel) map[string]string {
+	labels := StandardLabels(model)
+	labels["llm.nebari.dev/model-name"] = model.Name
+	return labels
 }
 
 func buildAPIKeySecret(model *llmv1alpha1.LLMModel, labels map[string]string) *corev1.Secret {
@@ -67,7 +78,7 @@ func buildAPIKeyMetadataConfigMap(model *llmv1alpha1.LLMModel, labels map[string
 	}
 }
 
-func buildExternalSecurityPolicy(model *llmv1alpha1.LLMModel, _ *config.OperatorConfig) *unstructured.Unstructured {
+func buildExternalSecurityPolicy(model *llmv1alpha1.LLMModel) *unstructured.Unstructured {
 	name := model.Name + "-external-auth"
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/operator/internal/controller/reconcilers/auth.go
+++ b/operator/internal/controller/reconcilers/auth.go
@@ -67,7 +67,7 @@ func buildAPIKeyMetadataConfigMap(model *llmv1alpha1.LLMModel, labels map[string
 	}
 }
 
-func buildExternalSecurityPolicy(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig) *unstructured.Unstructured {
+func buildExternalSecurityPolicy(model *llmv1alpha1.LLMModel, _ *config.OperatorConfig) *unstructured.Unstructured {
 	name := model.Name + "-external-auth"
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/operator/internal/controller/reconcilers/auth_test.go
+++ b/operator/internal/controller/reconcilers/auth_test.go
@@ -12,7 +12,6 @@ import (
 const (
 	testAuthModelName = "my-model"
 	testAuthNamespace = "test-ns"
-	testAuthAPIKeysNS = "llm-api-keys"
 	testAuthSAName    = "nebari-llm-operator"
 )
 
@@ -47,7 +46,7 @@ func defaultAuthConfig() *config.OperatorConfig {
 		OIDCIssuerURL:       "https://oidc.example.com",
 		OIDCGroupsClaim:     "groups",
 		OIDCAudience:        "my-audience",
-		APIKeysNamespace:    testAuthAPIKeysNS,
+		APIKeysNamespace:    testAuthNamespace,
 	}
 }
 
@@ -74,8 +73,8 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 				if result.APIKeySecret.Name != APIKeySecretName(testAuthModelName) {
 					t.Errorf("expected name %q, got %q", APIKeySecretName(testAuthModelName), result.APIKeySecret.Name)
 				}
-				if result.APIKeySecret.Namespace != testAuthAPIKeysNS {
-					t.Errorf("expected namespace %s, got %q", testAuthAPIKeysNS, result.APIKeySecret.Namespace)
+				if result.APIKeySecret.Namespace != testAuthNamespace {
+					t.Errorf("expected namespace %s, got %q", testAuthNamespace, result.APIKeySecret.Namespace)
 				}
 			},
 		},
@@ -109,8 +108,8 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 				if result.APIKeyMetadataCM.Name != APIKeyMetadataConfigMapName(testAuthModelName) {
 					t.Errorf("expected name %q, got %q", APIKeyMetadataConfigMapName(testAuthModelName), result.APIKeyMetadataCM.Name)
 				}
-				if result.APIKeyMetadataCM.Namespace != testAuthAPIKeysNS {
-					t.Errorf("expected namespace %s, got %q", testAuthAPIKeysNS, result.APIKeyMetadataCM.Namespace)
+				if result.APIKeyMetadataCM.Namespace != testAuthNamespace {
+					t.Errorf("expected namespace %s, got %q", testAuthNamespace, result.APIKeyMetadataCM.Namespace)
 				}
 			},
 		},
@@ -128,13 +127,17 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 			},
 		},
 		{
-			name:  "Labels: Secret and ConfigMap include model-name and model-namespace labels",
+			name:  "Labels: Secret and ConfigMap include standard labels (managed-by)",
 			model: defaultAuthModel(),
 			cfg:   defaultAuthConfig(),
 			check: func(t *testing.T, result *AuthResources, err error) {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
+				// model-name / model-namespace labels were specific to the
+				// pre-#59 cross-namespace pattern. Now Secret + CM live in
+				// the model's own namespace, so namespace-of-origin doesn't
+				// need to be encoded as a label.
 				for _, resource := range []struct {
 					name   string
 					labels map[string]string
@@ -142,111 +145,9 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 					{"Secret", result.APIKeySecret.Labels},
 					{"ConfigMap", result.APIKeyMetadataCM.Labels},
 				} {
-					if resource.labels["llm.nebari.dev/model-name"] != testAuthModelName {
-						t.Errorf("%s: expected model-name label %s, got %q", resource.name, testAuthModelName, resource.labels["llm.nebari.dev/model-name"])
-					}
-					if resource.labels["llm.nebari.dev/model-namespace"] != testAuthNamespace {
-						t.Errorf("%s: expected model-namespace label %s, got %q", resource.name, testAuthNamespace, resource.labels["llm.nebari.dev/model-namespace"])
-					}
 					if resource.labels["app.kubernetes.io/managed-by"] != testAuthSAName {
 						t.Errorf("%s: expected managed-by label %s, got %q", resource.name, testAuthSAName, resource.labels["app.kubernetes.io/managed-by"])
 					}
-				}
-			},
-		},
-		{
-			name:  "ReferenceGrant: correct apiVersion and kind",
-			model: defaultAuthModel(),
-			cfg:   defaultAuthConfig(),
-			check: func(t *testing.T, result *AuthResources, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if result.ReferenceGrant == nil {
-					t.Fatal("expected ReferenceGrant to be non-nil")
-				}
-				if result.ReferenceGrant.GetAPIVersion() != "gateway.networking.k8s.io/v1beta1" {
-					t.Errorf("expected apiVersion gateway.networking.k8s.io/v1beta1, got %q", result.ReferenceGrant.GetAPIVersion())
-				}
-				if result.ReferenceGrant.GetKind() != "ReferenceGrant" {
-					t.Errorf("expected kind ReferenceGrant, got %q", result.ReferenceGrant.GetKind())
-				}
-			},
-		},
-		{
-			name:  "ReferenceGrant: namespace is cfg.APIKeysNamespace",
-			model: defaultAuthModel(),
-			cfg:   defaultAuthConfig(),
-			check: func(t *testing.T, result *AuthResources, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if result.ReferenceGrant.GetNamespace() != testAuthAPIKeysNS {
-					t.Errorf("expected namespace %s, got %q", testAuthAPIKeysNS, result.ReferenceGrant.GetNamespace())
-				}
-			},
-		},
-		{
-			name:  "ReferenceGrant: name includes both model name and namespace for uniqueness",
-			model: defaultAuthModel(),
-			cfg:   defaultAuthConfig(),
-			check: func(t *testing.T, result *AuthResources, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				expectedName := testAuthModelName + "-" + testAuthNamespace + "-ref-grant"
-				if result.ReferenceGrant.GetName() != expectedName {
-					t.Errorf("expected name %q, got %q", expectedName, result.ReferenceGrant.GetName())
-				}
-			},
-		},
-		{
-			name:  "ReferenceGrant: correct from (SecurityPolicy in model namespace)",
-			model: defaultAuthModel(),
-			cfg:   defaultAuthConfig(),
-			check: func(t *testing.T, result *AuthResources, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				spec := result.ReferenceGrant.Object["spec"].(map[string]interface{})
-				from := spec["from"].([]interface{})
-				if len(from) != 1 {
-					t.Fatalf("expected 1 from entry, got %d", len(from))
-				}
-				fromEntry := from[0].(map[string]interface{})
-				if fromEntry["group"] != "gateway.envoyproxy.io" {
-					t.Errorf("expected from group gateway.envoyproxy.io, got %q", fromEntry["group"])
-				}
-				if fromEntry["kind"] != "SecurityPolicy" {
-					t.Errorf("expected from kind SecurityPolicy, got %q", fromEntry["kind"])
-				}
-				if fromEntry["namespace"] != testAuthNamespace {
-					t.Errorf("expected from namespace %s, got %q", testAuthNamespace, fromEntry["namespace"])
-				}
-			},
-		},
-		{
-			name:  "ReferenceGrant: correct to (Secret by name in api-keys namespace)",
-			model: defaultAuthModel(),
-			cfg:   defaultAuthConfig(),
-			check: func(t *testing.T, result *AuthResources, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				spec := result.ReferenceGrant.Object["spec"].(map[string]interface{})
-				to := spec["to"].([]interface{})
-				if len(to) != 1 {
-					t.Fatalf("expected 1 to entry, got %d", len(to))
-				}
-				toEntry := to[0].(map[string]interface{})
-				if toEntry["group"] != "" {
-					t.Errorf("expected to group empty string, got %q", toEntry["group"])
-				}
-				if toEntry["kind"] != "Secret" {
-					t.Errorf("expected to kind Secret, got %q", toEntry["kind"])
-				}
-				if toEntry["name"] != APIKeySecretName(testAuthModelName) {
-					t.Errorf("expected to name %q, got %q", APIKeySecretName(testAuthModelName), toEntry["name"])
 				}
 			},
 		},
@@ -279,20 +180,20 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 			},
 		},
 		{
-			name:  "External SecurityPolicy: apiKeyAuth credentialRef to Secret in api-keys namespace",
+			name:  "External SecurityPolicy: apiKeyAuth credentialRef is same-namespace (no namespace field)",
 			model: defaultAuthModel(),
 			cfg:   defaultAuthConfig(),
 			check: func(t *testing.T, result *AuthResources, err error) {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
-				spec := result.ExternalSecurityPolicy.Object["spec"].(map[string]interface{})
-				apiKeyAuth := spec["apiKeyAuth"].(map[string]interface{})
-				credentialRefs := apiKeyAuth["credentialRefs"].([]interface{})
+				spec := result.ExternalSecurityPolicy.Object["spec"].(map[string]any)
+				apiKeyAuth := spec["apiKeyAuth"].(map[string]any)
+				credentialRefs := apiKeyAuth["credentialRefs"].([]any)
 				if len(credentialRefs) != 1 {
 					t.Fatalf("expected 1 credentialRef, got %d", len(credentialRefs))
 				}
-				credRef := credentialRefs[0].(map[string]interface{})
+				credRef := credentialRefs[0].(map[string]any)
 				if credRef["group"] != "" {
 					t.Errorf("expected group empty string, got %q", credRef["group"])
 				}
@@ -302,8 +203,10 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 				if credRef["name"] != APIKeySecretName(testAuthModelName) {
 					t.Errorf("expected name %q, got %q", APIKeySecretName(testAuthModelName), credRef["name"])
 				}
-				if credRef["namespace"] != testAuthAPIKeysNS {
-					t.Errorf("expected namespace %s, got %q", testAuthAPIKeysNS, credRef["namespace"])
+				// Per #59: Envoy Gateway's APIKeyAuth rejects any non-same-ns
+				// credentialRef, so we deliberately leave `namespace` unset.
+				if _, present := credRef["namespace"]; present {
+					t.Errorf("expected no namespace field on credentialRef, got %q", credRef["namespace"])
 				}
 			},
 		},
@@ -631,9 +534,6 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 				}
 				if result.APIKeyMetadataCM == nil {
 					t.Error("expected APIKeyMetadataCM to be non-nil even when both endpoints disabled")
-				}
-				if result.ReferenceGrant == nil {
-					t.Error("expected ReferenceGrant to be non-nil even when both endpoints disabled")
 				}
 			},
 		},

--- a/operator/internal/controller/reconcilers/auth_test.go
+++ b/operator/internal/controller/reconcilers/auth_test.go
@@ -46,7 +46,11 @@ func defaultAuthConfig() *config.OperatorConfig {
 		OIDCIssuerURL:       "https://oidc.example.com",
 		OIDCGroupsClaim:     "groups",
 		OIDCAudience:        "my-audience",
-		APIKeysNamespace:    testAuthNamespace,
+		// APIKeysNamespace is no longer used to PLACE Secrets (per #59).
+		// Leaving it empty matches the post-#59 default and ensures the
+		// pure-build tests are not entangled with the legacy-cleanup
+		// branch.
+		APIKeysNamespace: "",
 	}
 }
 

--- a/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
+++ b/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
@@ -38,9 +38,19 @@ import (
 var llmmodellog = logf.Log.WithName("llmmodel-resource")
 
 // SetupLLMModelWebhookWithManager registers the webhook for LLMModel in the manager.
-func SetupLLMModelWebhookWithManager(mgr ctrl.Manager) error {
+// operatorNamespace is the namespace the operator pod runs in; the webhook
+// rejects LLMModel CRs created in any other namespace because the API-key
+// Secret must live in the same namespace as the SecurityPolicy that
+// references it (Envoy Gateway's APIKeyAuth.credentialRefs does not honor
+// ReferenceGrant for cross-namespace refs - see #59) and the key-manager
+// can only read Secrets in its own namespace. An empty operatorNamespace
+// disables the check (used in tests that don't run inside a pod).
+func SetupLLMModelWebhookWithManager(mgr ctrl.Manager, operatorNamespace string) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&llmv1alpha1.LLMModel{}).
-		WithValidator(&LLMModelCustomValidator{Client: mgr.GetClient()}).
+		WithValidator(&LLMModelCustomValidator{
+			Client:            mgr.GetClient(),
+			OperatorNamespace: operatorNamespace,
+		}).
 		Complete()
 }
 
@@ -55,7 +65,8 @@ func SetupLLMModelWebhookWithManager(mgr ctrl.Manager) error {
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
 type LLMModelCustomValidator struct {
-	Client client.Client
+	Client            client.Client
+	OperatorNamespace string // pod namespace; LLMModels must live here. Empty disables the check.
 }
 
 var _ webhook.CustomValidator = &LLMModelCustomValidator{}
@@ -67,6 +78,10 @@ func (v *LLMModelCustomValidator) ValidateCreate(ctx context.Context, obj runtim
 		return nil, fmt.Errorf("expected a LLMModel object but got %T", obj)
 	}
 	llmmodellog.Info("Validation for LLMModel upon creation", "name", llmmodel.GetName())
+
+	if err := v.validateOperatorNamespace(llmmodel.Namespace); err != nil {
+		return nil, err
+	}
 
 	if err := v.validateNamespaceLabel(ctx, llmmodel.Namespace); err != nil {
 		return nil, err
@@ -90,6 +105,28 @@ func (v *LLMModelCustomValidator) ValidateCreate(ctx context.Context, obj runtim
 	return warnings, nil
 }
 
+// validateOperatorNamespace rejects LLMModels created outside the operator's
+// own namespace. The pack's auth model needs the API-key Secret to live in
+// the same namespace as the SecurityPolicy that references it (Envoy Gateway's
+// APIKeyAuth.credentialRefs does not honor ReferenceGrant); the simplest way
+// to keep that invariant is to require all LLMModels to live alongside the
+// operator and key-manager. Empty OperatorNamespace skips the check (used in
+// envtest setups that don't run the operator inside a pod).
+func (v *LLMModelCustomValidator) validateOperatorNamespace(namespace string) error {
+	if v.OperatorNamespace == "" {
+		return nil
+	}
+	if namespace != v.OperatorNamespace {
+		return fmt.Errorf(
+			"LLMModel must be created in the operator's namespace %q (got %q); "+
+				"the API-key Secret needs to be co-located with its SecurityPolicy "+
+				"because Envoy Gateway's APIKeyAuth rejects cross-namespace credentialRefs",
+			v.OperatorNamespace, namespace,
+		)
+	}
+	return nil
+}
+
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type LLMModel.
 func (v *LLMModelCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	llmmodel, ok := newObj.(*llmv1alpha1.LLMModel)
@@ -97,6 +134,10 @@ func (v *LLMModelCustomValidator) ValidateUpdate(ctx context.Context, oldObj, ne
 		return nil, fmt.Errorf("expected a LLMModel object for the newObj but got %T", newObj)
 	}
 	llmmodellog.Info("Validation for LLMModel upon update", "name", llmmodel.GetName())
+
+	if err := v.validateOperatorNamespace(llmmodel.Namespace); err != nil {
+		return nil, err
+	}
 
 	if err := v.validateNamespaceLabel(ctx, llmmodel.Namespace); err != nil {
 		return nil, err

--- a/operator/internal/webhook/v1alpha1/validate_operator_namespace_test.go
+++ b/operator/internal/webhook/v1alpha1/validate_operator_namespace_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package v1alpha1
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateOperatorNamespace(t *testing.T) {
+	tests := []struct {
+		name              string
+		operatorNamespace string
+		modelNamespace    string
+		wantErr           bool
+		wantErrContains   string
+	}{
+		{
+			name:              "empty operator namespace disables check",
+			operatorNamespace: "",
+			modelNamespace:    "anywhere",
+			wantErr:           false,
+		},
+		{
+			name:              "matching namespace is accepted",
+			operatorNamespace: "nebari-llm-serving-system",
+			modelNamespace:    "nebari-llm-serving-system",
+			wantErr:           false,
+		},
+		{
+			name:              "mismatched namespace is rejected",
+			operatorNamespace: "nebari-llm-serving-system",
+			modelNamespace:    "default",
+			wantErr:           true,
+			wantErrContains:   "nebari-llm-serving-system",
+		},
+		{
+			name:              "empty model namespace against set operator namespace is rejected",
+			operatorNamespace: "nebari-llm-serving-system",
+			modelNamespace:    "",
+			wantErr:           true,
+			wantErrContains:   "nebari-llm-serving-system",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &LLMModelCustomValidator{OperatorNamespace: tt.operatorNamespace}
+			err := v.validateOperatorNamespace(tt.modelNamespace)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("expected error to contain %q, got %q", tt.wantErrContains, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/operator/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/operator/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -109,7 +109,9 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = SetupLLMModelWebhookWithManager(mgr)
+	// Empty operatorNamespace disables the same-ns enforcement so the
+	// envtest suite can create LLMModels in any namespace it wants.
+	err = SetupLLMModelWebhookWithManager(mgr, "")
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook


### PR DESCRIPTION
Closes #59.

## Summary

Envoy Gateway's `SecurityPolicy.spec.apiKeyAuth.credentialRefs` rejects any cross-namespace Secret reference and does **not** honor `ReferenceGrant` for that field. The pre-existing pattern of keeping API-key Secrets in a dedicated `llm-api-keys` namespace and bridging via a ReferenceGrant left every model SecurityPolicy in `Invalid` state, which surfaced as HTTP 500 `direct_response` from Envoy for every model API request (full diagnosis in #59).

Move LLMModel CRs, model pods, API-key Secrets/ConfigMaps, and the key-manager into a single namespace - the operator's own namespace - so the SecurityPolicy can reference its credential Secret without crossing namespaces.

## What changed

**Operator:**
- `auth.go`: drop `cfg.APIKeysNamespace`; the Secret + metadata ConfigMap now live in `model.Namespace`. Drop `buildReferenceGrant`. Drop the `namespace` field from SP `apiKeyAuth.credentialRefs`.
- `llmmodel_controller.go`: drop the `ensureNamespace(api-keys)` call. The legacy ReferenceGrant cleanup is retained as a best-effort path during finalizer execution so clusters originally deployed against a separate api-keys namespace can still drain.
- `webhook/llmmodel_webhook.go`: reject LLMModel CRs created outside the operator's own namespace. `POD_NAMESPACE` feeds the check via the downward API; empty disables it (envtest only).
- `config.go`: `APIKeysNamespace` retained but only as a legacy cleanup hint, default empty.

**Chart:**
- Drop `values.apiKeysNamespace`.
- Delete `templates/api-keys-namespace.yaml`.
- Rebind `key-manager-role` + `key-manager-rolebinding` to the operator namespace.
- Key-manager Deployment: `LLM_API_KEYS_NAMESPACE` now sourced from the downward API (`metadata.namespace`).
- Operator Deployment: add `POD_NAMESPACE` from the downward API; drop `LLM_API_KEYS_NAMESPACE`.

**Dev manifests, examples, docs:** updated to the new layout. `docs/design.md` gets a #59 callout at the top; full doc rewrite left to a follow-up since the original architecture is interleaved across sections.

**Tests:** drop ReferenceGrant assertions; assert Secret/ConfigMap namespace equals `model.Namespace`; assert SecurityPolicy `credentialRefs` has no `namespace` field.

## Migration note

Existing deployments with API keys in `llm-api-keys` will not see those keys after upgrade because the operator now looks for Secrets in the model's namespace. **Users will need to re-issue keys via the key-manager UI.** Worth calling out in release notes.

## Test plan

- [x] `go test ./...` all green (operator)
- [x] `helm lint charts/nebari-llm-serving` clean
- [x] `helm template` renders zero references to `llm-api-keys`
- [x] Webhook rejects LLMModel created in a non-operator namespace (envtest exercises the empty-namespace bypass; live cluster will exercise the enforcement path during the smoke test below)
- [ ] Smoke on llmd-test cluster: deploy operator from this branch, recreate LLMModel in `nebari-llm-serving-system`, verify SP becomes Accepted, mint a new API key, hit `/v1/chat/completions` and get a 200 with a model response

## Draft because

Pending the live-cluster smoke test on llmd-test (in progress).