### PR TITLE
fix(#61): use Keycloak JWKS path for internal SecurityPolicy

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -317,6 +317,8 @@ In-cluster app -> Authorization: Bearer <JWT> -> Envoy AI Gateway (internal) -> 
 - JWT validation: verifies signature against the OIDC issuer's JWKS endpoint, checks audience, extracts groups from the configured claim, validates group membership against the model's `access.groups`
 - No browser redirects - this is pure bearer token validation for service-to-service calls
 
+JWKS endpoint resolution: the operator currently constructs the JWKS URI as `<issuerURL>/protocol/openid-connect/certs`, the Keycloak convention. This matches the rest of the pack's Keycloak assumptions (issuer URL format, group-membership mapper) but means a non-Keycloak OIDC provider will not work out of the box even though the surrounding config fields are provider-agnostic. The long-term fix is to fetch `<issuerURL>/.well-known/openid-configuration` and read `jwks_uri` from the discovery document; until that lands, treat the internal SecurityPolicy JWKS path as Keycloak-only. Tracked in issue #61.
+
 The `jwt` SecurityPolicy type in Envoy Gateway validates bearer tokens without OIDC redirect flows. It takes the issuer URL, fetches the JWKS, and validates the token signature, expiry, and claims. This is the correct mechanism for service-to-service auth where the calling service already has a JWT.
 
 Note on JWT availability: in Nebari, JupyterHub injects tokens into user pods. For other in-cluster services, the application must handle OIDC login and forward the resulting token. If a service cannot obtain a JWT, it should use the external endpoint with an API key instead.

--- a/operator/internal/controller/reconcilers/auth.go
+++ b/operator/internal/controller/reconcilers/auth.go
@@ -154,8 +154,11 @@ func buildInternalSecurityPolicy(model *llmv1alpha1.LLMModel, cfg *config.Operat
 	provider := map[string]interface{}{
 		"name":   "oidc",
 		"issuer": cfg.OIDCIssuerURL,
+		// Keycloak-specific JWKS path. The rest of the pack assumes Keycloak
+		// (issuer URL convention, group-membership mapper, etc.) and Keycloak
+		// does not serve JWKS at /.well-known/jwks.json. See issue #61.
 		"remoteJWKS": map[string]interface{}{
-			"uri": cfg.OIDCIssuerURL + "/.well-known/jwks.json",
+			"uri": cfg.OIDCIssuerURL + "/protocol/openid-connect/certs",
 		},
 		"claimToHeaders": []interface{}{
 			map[string]interface{}{

--- a/operator/internal/controller/reconcilers/auth_test.go
+++ b/operator/internal/controller/reconcilers/auth_test.go
@@ -407,7 +407,7 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 					t.Errorf("expected issuer https://oidc.example.com, got %q", provider["issuer"])
 				}
 				remoteJWKS := provider["remoteJWKS"].(map[string]interface{})
-				expectedURI := "https://oidc.example.com/.well-known/jwks.json"
+				expectedURI := "https://oidc.example.com/protocol/openid-connect/certs"
 				if remoteJWKS["uri"] != expectedURI {
 					t.Errorf("expected JWKS URI %q, got %q", expectedURI, remoteJWKS["uri"])
 				}


### PR DESCRIPTION
## Summary

The operator's internal SecurityPolicy points the JWT provider at `<issuer>/.well-known/jwks.json`, which Keycloak does not serve (404). The actual Keycloak JWKS endpoint is `<issuer>/protocol/openid-connect/certs`, advertised in the discovery document at `/.well-known/openid-configuration`.

Symptoms before this fix:
- Envoy's JWT auth filter spammed `Jwks async fetching ... failed` once per second.
- JWT validation never worked, so every internal model API call returned `HTTP 500 direct_response`.
- This was masked while the cross-namespace `credentialRef` bug (#59) was still in flight.

## Approach

Option 1 from #61: hardcoded path swap. The rest of the pack already assumes Keycloak (issuer URL convention, group-membership mapper, etc.), so a Keycloak-specific path is consistent with existing assumptions. A provider-agnostic OIDC discovery fetch is the right long-term fix and is left as a separate refactor.

Fixes #61

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/controller/reconcilers/...` passes (envtest suites need kubebuilder binaries; not run locally)
- [ ] CI runs full test + lint matrix
- [ ] Smoke: redeploy on llmd-test, confirm Envoy proxy log no longer spams JWKS fetch failures and an internal model call returns a real upstream response (not a 500 direct_response)