### PR TITLE
fix(#64): disambiguate external and internal HTTPRoutes by Host header

### DIFF
--- a/operator/internal/controller/llmmodel_controller.go
+++ b/operator/internal/controller/llmmodel_controller.go
@@ -550,17 +550,20 @@ func (r *LLMModelReconciler) updateStatus(
 		}
 	}
 
-	// Update endpoint URLs
+	// Update endpoint URLs. Go through reconcilers.EffectiveSubdomain so the
+	// status URL, the routing builder, and the validating webhook all derive
+	// the subdomain identically; if the helper grows additional rules
+	// (length cap changes, reserved-name list, etc.) every consumer picks
+	// them up.
 	if r.Config != nil {
-		subdomain := model.Spec.Endpoints.External.Subdomain
-		if subdomain == "" {
-			subdomain = reconcilers.Slugify(model.Name)
-		}
-		if r.Config.ExternalGatewayName != "" {
-			fresh.Status.Endpoints.External = "https://" + reconcilers.ExternalHostname(subdomain, r.Config.BaseDomain)
-		}
-		if r.Config.InternalGatewayName != "" {
-			fresh.Status.Endpoints.Internal = "https://" + reconcilers.InternalHostname(subdomain, r.Config.BaseDomain)
+		subdomain, err := reconcilers.EffectiveSubdomain(model)
+		if err == nil {
+			if r.Config.ExternalGatewayName != "" {
+				fresh.Status.Endpoints.External = "https://" + reconcilers.ExternalHostname(subdomain, r.Config.BaseDomain)
+			}
+			if r.Config.InternalGatewayName != "" {
+				fresh.Status.Endpoints.Internal = "https://" + reconcilers.InternalHostname(subdomain, r.Config.BaseDomain)
+			}
 		}
 	}
 

--- a/operator/internal/controller/reconcilers/common.go
+++ b/operator/internal/controller/reconcilers/common.go
@@ -65,6 +65,26 @@ func APIKeyMetadataConfigMapName(modelName string) string {
 	return modelName + "-api-key-metadata"
 }
 
+// EffectiveSubdomain returns the subdomain that will be used for this LLMModel.
+// It uses spec.endpoints.external.subdomain if set, otherwise it slugifies the
+// model name. It also validates that the result does not exceed 63 characters
+// (the maximum length of a single DNS label).
+func EffectiveSubdomain(model *llmv1alpha1.LLMModel) (string, error) {
+	subdomain := model.Spec.Endpoints.External.Subdomain
+	if subdomain == "" {
+		subdomain = Slugify(model.Name)
+	}
+
+	if len(subdomain) > 63 {
+		return "", fmt.Errorf(
+			"effective subdomain %q is %d characters long; subdomains must be 63 characters or fewer",
+			subdomain, len(subdomain),
+		)
+	}
+
+	return subdomain, nil
+}
+
 // ExternalHostname returns the external hostname for a model's endpoint.
 func ExternalHostname(subdomain, baseDomain string) string {
 	return subdomain + ".llm." + baseDomain

--- a/operator/internal/controller/reconcilers/common_test.go
+++ b/operator/internal/controller/reconcilers/common_test.go
@@ -302,3 +302,64 @@ func TestInternalHostname(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveSubdomain(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelName string
+		subdomain string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "explicit subdomain is used as-is",
+			modelName: "anything",
+			subdomain: "qwen3-5-35b",
+			want:      "qwen3-5-35b",
+		},
+		{
+			name:      "empty subdomain falls back to slugified model name",
+			modelName: "Qwen3_30B-A3B",
+			subdomain: "",
+			want:      "qwen3-30b-a3b",
+		},
+		{
+			name:      "explicit subdomain over 63 chars is rejected",
+			modelName: "anything",
+			subdomain: strings.Repeat("a", 64),
+			wantErr:   true,
+		},
+		{
+			name:      "explicit subdomain at exactly 63 chars is accepted",
+			modelName: "anything",
+			subdomain: strings.Repeat("a", 63),
+			want:      strings.Repeat("a", 63),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &llmv1alpha1.LLMModel{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.modelName},
+				Spec: llmv1alpha1.LLMModelSpec{
+					Endpoints: llmv1alpha1.EndpointSpec{
+						External: llmv1alpha1.ExternalEndpointSpec{Subdomain: tt.subdomain},
+					},
+				},
+			}
+			got, err := EffectiveSubdomain(model)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (got=%q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("EffectiveSubdomain = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/operator/internal/controller/reconcilers/routing.go
+++ b/operator/internal/controller/reconcilers/routing.go
@@ -26,13 +26,21 @@ func boolOrDefault(b *bool, def bool) bool { //nolint:unparam // def is always t
 //
 // Each AIGatewayRoute is rendered by the Envoy AI Gateway controller into an
 // HTTPRoute. AIGatewayRouteSpec itself does not currently expose a hostnames
-// field (the upstream controller does not propagate hostnames onto the
-// generated HTTPRoute), so we ensure deterministic per-model routing by
-// constraining every rule with a `Host` header match for the model's FQDN.
-// Without a host constraint, every route attached to a Gateway matches every
-// request and SecurityPolicy attachment becomes non-deterministic - an
-// external (API key) request can be matched against the internal route's JWT
-// filter and rejected. See issue #64.
+// field (verified against envoyproxy/ai-gateway main; the upstream controller
+// also does not propagate hostnames onto the generated HTTPRoute), so we
+// ensure deterministic per-model routing by constraining every rule with a
+// `Host` header match for the model's FQDN. Without a host constraint, every
+// route attached to a Gateway matches every request and SecurityPolicy
+// attachment becomes non-deterministic - an external (API key) request can be
+// matched against the internal route's JWT filter and rejected. See issue #64.
+//
+// HTTP/2 note: production traffic is HTTP/2 (HTTPS through Envoy). The Gateway
+// API spec mandates that conformant implementations treat the HTTP/1.1 Host
+// header and the HTTP/2 :authority pseudo-header as equivalent for header
+// matching (see HTTPHeaderMatch in the Gateway API spec). Envoy normalises
+// :authority to Host before HTTPRoute header matching runs, so an Exact Host
+// matcher fires identically under both protocols. Revisit if upstream changes
+// either assumption, or migrate to spec.hostnames once it is propagated.
 func BuildRoutingResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig) (*RoutingResources, error) {
 	result := &RoutingResources{}
 

--- a/operator/internal/controller/reconcilers/routing.go
+++ b/operator/internal/controller/reconcilers/routing.go
@@ -23,8 +23,23 @@ func boolOrDefault(b *bool, def bool) bool { //nolint:unparam // def is always t
 
 // BuildRoutingResources is a pure function that computes the AIGatewayRoute resources
 // for external and internal endpoints of the given model.
+//
+// Each AIGatewayRoute is rendered by the Envoy AI Gateway controller into an
+// HTTPRoute. AIGatewayRouteSpec itself does not currently expose a hostnames
+// field (the upstream controller does not propagate hostnames onto the
+// generated HTTPRoute), so we ensure deterministic per-model routing by
+// constraining every rule with a `Host` header match for the model's FQDN.
+// Without a host constraint, every route attached to a Gateway matches every
+// request and SecurityPolicy attachment becomes non-deterministic - an
+// external (API key) request can be matched against the internal route's JWT
+// filter and rejected. See issue #64.
 func BuildRoutingResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig) (*RoutingResources, error) {
 	result := &RoutingResources{}
+
+	subdomain, err := EffectiveSubdomain(model)
+	if err != nil {
+		return nil, err
+	}
 
 	if boolOrDefault(model.Spec.Endpoints.External.Enabled, true) {
 		result.ExternalRoute = buildAIGatewayRoute(
@@ -34,6 +49,7 @@ func BuildRoutingResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConf
 			cfg.ExternalGatewayName,
 			cfg.ExternalGatewayNS,
 			model.Name,
+			ExternalHostname(subdomain, cfg.BaseDomain),
 		)
 	}
 
@@ -45,6 +61,7 @@ func BuildRoutingResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConf
 			cfg.InternalGatewayName,
 			cfg.InternalGatewayNS,
 			model.Name,
+			InternalHostname(subdomain, cfg.BaseDomain),
 		)
 	}
 
@@ -56,6 +73,7 @@ func buildAIGatewayRoute(
 	labels map[string]string,
 	gatewayName, gatewayNS string,
 	poolName string,
+	hostname string,
 ) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -73,11 +91,24 @@ func buildAIGatewayRoute(
 						"namespace": gatewayNS,
 					},
 				},
-				// Note: AIGatewayRoute does not support hostnames directly.
-				// Hostname-based routing will be addressed in a future version
-				// via Gateway listener configuration or EnvoyPatchPolicy.
 				"rules": []interface{}{
 					map[string]interface{}{
+						// Match on the Host header so this rule only fires for
+						// the model's FQDN. The Envoy AI Gateway controller
+						// propagates Headers matchers onto the generated
+						// HTTPRoute, giving us deterministic per-model routing
+						// even when multiple routes share a Gateway listener.
+						"matches": []interface{}{
+							map[string]interface{}{
+								"headers": []interface{}{
+									map[string]interface{}{
+										"type":  "Exact",
+										"name":  "Host",
+										"value": hostname,
+									},
+								},
+							},
+						},
 						"backendRefs": []interface{}{
 							map[string]interface{}{
 								"group": "inference.networking.k8s.io",

--- a/operator/internal/controller/reconcilers/routing_test.go
+++ b/operator/internal/controller/reconcilers/routing_test.go
@@ -234,8 +234,6 @@ func TestBuildRoutingResources(t *testing.T) { //nolint:gocyclo // table-driven 
 				}
 			},
 		},
-		// NOTE: hostname tests removed - AIGatewayRoute does not support hostnames.
-		// Subdomain/hostname routing will be addressed via Gateway listener config.
 		{
 			name: "External disabled (enabled=false): ExternalRoute is nil",
 			model: func() *llmv1alpha1.LLMModel {

--- a/operator/internal/controller/reconcilers/routing_test.go
+++ b/operator/internal/controller/reconcilers/routing_test.go
@@ -331,7 +331,7 @@ func TestBuildRoutingResources(t *testing.T) { //nolint:gocyclo // table-driven 
 			},
 		},
 		{
-			name: "Both routes: Host header matches use Exact type",
+			name:  "Both routes: Host header matches use Exact type",
 			model: defaultRoutingModel(),
 			cfg:   defaultRoutingConfig(),
 			check: func(t *testing.T, result *RoutingResources, err error) {

--- a/operator/internal/controller/reconcilers/routing_test.go
+++ b/operator/internal/controller/reconcilers/routing_test.go
@@ -5,10 +5,67 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
 	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
 )
+
+// hostHeaderMatch extracts the Host header matcher from the first rule of the
+// given AIGatewayRoute. It fatally fails the test if the structure does not
+// match the operator's expected layout.
+func hostHeaderMatch(t *testing.T, route *unstructured.Unstructured) map[string]interface{} {
+	t.Helper()
+	if route == nil {
+		t.Fatal("expected route to be non-nil")
+	}
+	spec, ok := route.Object["spec"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected spec to be a map, got %T", route.Object["spec"])
+	}
+	rules, ok := spec["rules"].([]interface{})
+	if !ok || len(rules) == 0 {
+		t.Fatalf("expected at least one rule, got %v", spec["rules"])
+	}
+	rule, ok := rules[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected rule to be a map, got %T", rules[0])
+	}
+	matches, ok := rule["matches"].([]interface{})
+	if !ok || len(matches) == 0 {
+		t.Fatalf("expected at least one match on rule, got %v", rule["matches"])
+	}
+	match, ok := matches[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected match to be a map, got %T", matches[0])
+	}
+	headers, ok := match["headers"].([]interface{})
+	if !ok || len(headers) == 0 {
+		t.Fatalf("expected at least one header matcher, got %v", match["headers"])
+	}
+	for _, h := range headers {
+		header, ok := h.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if header["name"] == "Host" {
+			return header
+		}
+	}
+	t.Fatalf("did not find a Host header matcher in %v", headers)
+	return nil
+}
+
+// hostHeaderMatchValue returns the value of the Host header matcher.
+func hostHeaderMatchValue(t *testing.T, route *unstructured.Unstructured) string {
+	t.Helper()
+	header := hostHeaderMatch(t, route)
+	v, ok := header["value"].(string)
+	if !ok {
+		t.Fatalf("expected Host header value to be a string, got %T", header["value"])
+	}
+	return v
+}
 
 func defaultRoutingModel() *llmv1alpha1.LLMModel {
 	return &llmv1alpha1.LLMModel{
@@ -72,8 +129,59 @@ func TestBuildRoutingResources(t *testing.T) { //nolint:gocyclo // table-driven 
 				}
 			},
 		},
-		// NOTE: AIGatewayRoute does not support hostnames directly.
-		// Hostname-based routing will be addressed in a future version.
+		{
+			name:  "External: rule has Host header match for external FQDN (default subdomain from name slugification)",
+			model: defaultRoutingModel(),
+			cfg:   defaultRoutingConfig(),
+			check: func(t *testing.T, result *RoutingResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got := hostHeaderMatchValue(t, result.ExternalRoute)
+				want := "my-model.llm.example.com"
+				if got != want {
+					t.Errorf("expected external Host header match %q, got %q", want, got)
+				}
+			},
+		},
+		{
+			name: "External: rule has Host header match using explicit subdomain from spec",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultRoutingModel()
+				m.Spec.Endpoints.External.Subdomain = "custom-sub"
+				return m
+			}(),
+			cfg: defaultRoutingConfig(),
+			check: func(t *testing.T, result *RoutingResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got := hostHeaderMatchValue(t, result.ExternalRoute)
+				want := "custom-sub.llm.example.com"
+				if got != want {
+					t.Errorf("expected external Host header match %q, got %q", want, got)
+				}
+			},
+		},
+		{
+			name: "External: rule has Host header match for slugified multi-part model name",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultRoutingModel()
+				m.Name = "Qwen3_30B-A3B"
+				return m
+			}(),
+			cfg: defaultRoutingConfig(),
+			check: func(t *testing.T, result *RoutingResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got := hostHeaderMatchValue(t, result.ExternalRoute)
+				want := "qwen3-30b-a3b.llm.example.com"
+				if got != want {
+					t.Errorf("expected external Host header match %q, got %q", want, got)
+				}
+			},
+		},
 		{
 			name:  "External: parentRef points to external gateway from config",
 			model: defaultRoutingModel(),
@@ -171,7 +279,84 @@ func TestBuildRoutingResources(t *testing.T) { //nolint:gocyclo // table-driven 
 				}
 			},
 		},
-		// NOTE: Internal hostname test removed - AIGatewayRoute does not support hostnames.
+		{
+			name:  "Internal: rule has Host header match for internal FQDN (default subdomain)",
+			model: defaultRoutingModel(),
+			cfg:   defaultRoutingConfig(),
+			check: func(t *testing.T, result *RoutingResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got := hostHeaderMatchValue(t, result.InternalRoute)
+				want := "my-model.llm-internal.example.com"
+				if got != want {
+					t.Errorf("expected internal Host header match %q, got %q", want, got)
+				}
+			},
+		},
+		{
+			name: "Internal: rule has Host header match using explicit subdomain from spec",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultRoutingModel()
+				m.Spec.Endpoints.External.Subdomain = "custom-sub"
+				return m
+			}(),
+			cfg: defaultRoutingConfig(),
+			check: func(t *testing.T, result *RoutingResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got := hostHeaderMatchValue(t, result.InternalRoute)
+				want := "custom-sub.llm-internal.example.com"
+				if got != want {
+					t.Errorf("expected internal Host header match %q, got %q", want, got)
+				}
+			},
+		},
+		{
+			name: "Internal: rule has Host header match for slugified multi-part model name",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultRoutingModel()
+				m.Name = "Qwen3_30B-A3B"
+				return m
+			}(),
+			cfg: defaultRoutingConfig(),
+			check: func(t *testing.T, result *RoutingResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				got := hostHeaderMatchValue(t, result.InternalRoute)
+				want := "qwen3-30b-a3b.llm-internal.example.com"
+				if got != want {
+					t.Errorf("expected internal Host header match %q, got %q", want, got)
+				}
+			},
+		},
+		{
+			name: "Both routes: Host header matches use Exact type",
+			model: defaultRoutingModel(),
+			cfg:   defaultRoutingConfig(),
+			check: func(t *testing.T, result *RoutingResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				for _, route := range []struct {
+					name string
+					r    *unstructured.Unstructured
+				}{
+					{"external", result.ExternalRoute},
+					{"internal", result.InternalRoute},
+				} {
+					header := hostHeaderMatch(t, route.r)
+					if header["type"] != "Exact" {
+						t.Errorf("%s: expected Host match type Exact, got %v", route.name, header["type"])
+					}
+					if header["name"] != "Host" {
+						t.Errorf("%s: expected header name Host, got %v", route.name, header["name"])
+					}
+				}
+			},
+		},
 		{
 			name:  "Internal: parentRef points to internal gateway from config",
 			model: defaultRoutingModel(),

--- a/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
+++ b/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
@@ -91,7 +91,7 @@ func (v *LLMModelCustomValidator) ValidateCreate(ctx context.Context, obj runtim
 		return nil, err
 	}
 
-	subdomain, err := effectiveSubdomain(llmmodel)
+	subdomain, err := reconcilers.EffectiveSubdomain(llmmodel)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (v *LLMModelCustomValidator) ValidateUpdate(ctx context.Context, oldObj, ne
 		return nil, err
 	}
 
-	subdomain, err := effectiveSubdomain(llmmodel)
+	subdomain, err := reconcilers.EffectiveSubdomain(llmmodel)
 	if err != nil {
 		return nil, err
 	}
@@ -210,13 +210,6 @@ func (v *LLMModelCustomValidator) validateNamespaceLabel(ctx context.Context, na
 	return nil
 }
 
-// effectiveSubdomain returns the subdomain that will be used for this LLMModel.
-// It delegates to reconcilers.EffectiveSubdomain so the webhook and the
-// controller agree on the value.
-func effectiveSubdomain(llmmodel *llmv1alpha1.LLMModel) (string, error) {
-	return reconcilers.EffectiveSubdomain(llmmodel)
-}
-
 // validateSubdomainCollision checks that no other LLMModel across all namespaces
 // uses the same effective subdomain. The model identified by (excludeNamespace, excludeName)
 // is excluded from the check (used for updates).
@@ -237,7 +230,7 @@ func (v *LLMModelCustomValidator) validateSubdomainCollision(
 			continue
 		}
 
-		existingSubdomain, err := effectiveSubdomain(existing)
+		existingSubdomain, err := reconcilers.EffectiveSubdomain(existing)
 		if err != nil {
 			// If an existing model has an invalid subdomain, skip it rather than
 			// blocking new creates.

--- a/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
+++ b/operator/internal/webhook/v1alpha1/llmmodel_webhook.go
@@ -211,22 +211,10 @@ func (v *LLMModelCustomValidator) validateNamespaceLabel(ctx context.Context, na
 }
 
 // effectiveSubdomain returns the subdomain that will be used for this LLMModel.
-// It uses spec.endpoints.external.subdomain if set, otherwise it slugifies the model name.
-// It also validates that the result does not exceed 63 characters.
+// It delegates to reconcilers.EffectiveSubdomain so the webhook and the
+// controller agree on the value.
 func effectiveSubdomain(llmmodel *llmv1alpha1.LLMModel) (string, error) {
-	subdomain := llmmodel.Spec.Endpoints.External.Subdomain
-	if subdomain == "" {
-		subdomain = reconcilers.Slugify(llmmodel.Name)
-	}
-
-	if len(subdomain) > 63 {
-		return "", fmt.Errorf(
-			"effective subdomain %q is %d characters long; subdomains must be 63 characters or fewer",
-			subdomain, len(subdomain),
-		)
-	}
-
-	return subdomain, nil
+	return reconcilers.EffectiveSubdomain(llmmodel)
 }
 
 // validateSubdomainCollision checks that no other LLMModel across all namespaces


### PR DESCRIPTION
## Summary

For each LLMModel the operator generates two AIGatewayRoutes (external + internal). The Envoy AI Gateway controller renders each into an HTTPRoute. Both came out matching every request that hit their parent Gateway, so SecurityPolicy attachment was non-deterministic - external API-key calls could be matched against the internal route's JWT filter and rejected with HTTP 500 direct_response. We hit this on llmd-test once #59 and #61 cleared.

## Approach

The issue body suggested setting `hostnames` on the AIGatewayRoute spec. Upstream verification (`envoyproxy/ai-gateway` main, `api/v1alpha1/ai_gateway_route.go` and the controller's HTTPRoute renderer):

- AIGatewayRouteSpec has only ParentRefs / Rules / LLMRequestCosts. No `hostnames` field.
- The controller never sets `Hostnames` on the generated HTTPRoute either.

Setting `hostnames` would have been silently dropped by the unstructured client. Instead, constrain every generated rule with an Exact-match `Host` header equal to the model's FQDN. The AI Gateway controller does propagate `Headers` matchers onto the generated HTTPRoute, so Envoy ends up matching on `Host` and the routes stop colliding.

External hostname uses `ExternalHostname(subdomain, baseDomain)` -> `<sub>.llm.<base>`.
Internal hostname uses `InternalHostname(subdomain, baseDomain)` -> `<sub>.llm-internal.<base>` (matches the convention in `docs/design.md` line ~314).

Also extracted `effectiveSubdomain` from the webhook into an exported `reconcilers.EffectiveSubdomain`. The webhook now delegates so the controller and validating webhook can never disagree on the value.

Fixes #64

## Test plan

- [x] go build / vet / test green for `operator/internal/controller/reconcilers/...` (16 routing subtests)
- [x] No new operator config fields, no chart values changes - existing deployments unaffected
- [ ] CI runs full matrix
- [ ] Smoke on llmd-test (or fresh redeploy): external API-key request reaches the model and an internal JWT request reaches the model; neither hits the wrong SecurityPolicy