### PR TITLE
chore(release): cut v0.1.0-alpha.2

### DIFF
--- a/charts/nebari-llm-serving/Chart.yaml
+++ b/charts/nebari-llm-serving/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nebari-llm-serving
 description: Nebari software pack for serving LLMs via llm-d
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.0-alpha.2
+appVersion: "0.1.0-alpha.2"

--- a/charts/nebari-llm-serving/templates/key-manager-deployment.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: {{ include "nebari-llm-serving.fullname" . }}-key-manager
       containers:
         - name: key-manager
-          image: {{ .Values.keyManager.image.repository }}:{{ .Values.keyManager.image.tag }}
+          image: {{ .Values.keyManager.image.repository }}:{{ .Values.keyManager.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.keyManager.image.pullPolicy | default "IfNotPresent" }}
           ports:
             - containerPort: 8080

--- a/charts/nebari-llm-serving/templates/operator-deployment.yaml
+++ b/charts/nebari-llm-serving/templates/operator-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: {{ include "nebari-llm-serving.fullname" . }}-operator
       containers:
         - name: manager
-          image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}
+          image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.operator.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: LLM_BASE_DOMAIN

--- a/charts/nebari-llm-serving/values.yaml
+++ b/charts/nebari-llm-serving/values.yaml
@@ -39,7 +39,10 @@ keyManager:
   enabled: true
   image:
     repository: ghcr.io/nebari-dev/nebari-llm-serving-pack/key-manager
-    tag: latest
+    # tag defaults to .Chart.AppVersion when empty so the chart version and
+    # the image version always move together. Override only when testing a
+    # specific image build (e.g. tag: 0.1.0-alpha.2 or tag: sha-abc1234).
+    tag: ""
     pullPolicy: Always
   auditInterval: 5m
   oidcUserinfoURL: ""
@@ -90,7 +93,10 @@ keyManager:
 operator:
   image:
     repository: ghcr.io/nebari-dev/nebari-llm-serving-pack/operator
-    tag: latest
+    # tag defaults to .Chart.AppVersion when empty so the chart version and
+    # the image version always move together. Override only when testing a
+    # specific image build (e.g. tag: 0.1.0-alpha.2 or tag: sha-abc1234).
+    tag: ""
     pullPolicy: Always
 
 


### PR DESCRIPTION
## Summary

Bumps chart version + appVersion to \`0.1.0-alpha.2\` and defaults the operator + key-manager image tags to \`.Chart.AppVersion\` when not explicitly overridden. The chart and the images now move together on every release.

## What lands in alpha.2 (since alpha.1)

- #60 fix(#59): collapse pack into a single namespace
- #62 fix(#61): use Keycloak JWKS path for internal SecurityPolicy
- #63 fix(#57,#58): sanitize username for k8s data keys; log handler errors
- #70 fix(#64): disambiguate external and internal HTTPRoutes by Host header  *(MVP)*
- #71 chart+docs: NebariApp routing default + production install runbook   *(MVP)*

## Release sequence

1. Merge this PR. CI builds new \`latest\` images for the merged SHA.
2. Tag the merge commit \`v0.1.0-alpha.2\`. CI publishes \`0.1.0-alpha.2\` images via the existing semver tag rule (\`type=semver,pattern=v{{version}}\` strips the v prefix).
3. Repoint llmd-test (and other downstream apps) at \`v0.1.0-alpha.2\` and drop the per-cluster image-tag overrides.

## Test plan

- [x] \`helm lint\` clean
- [x] \`helm template\` resolves both image tags to \`0.1.0-alpha.2\` from .Chart.AppVersion when no override is set
- [x] Override path still works (\`--set operator.image.tag=sha-deadbeef\` produces the literal tag)
- [ ] CI matrix
- [ ] Tag created post-merge, build-images workflow publishes \`0.1.0-alpha.2\` to GHCR
- [ ] Fresh redeploy of llmd-test against \`v0.1.0-alpha.2\` reaches the validation checklist in \`docs/install-production.md\`