### PR TITLE
fix(alpha.6): narrow InferencePool selector to exclude EPP pod

### DIFF
--- a/charts/nebari-llm-serving/Chart.yaml
+++ b/charts/nebari-llm-serving/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nebari-llm-serving
 description: Nebari software pack for serving LLMs via llm-d
 type: application
-version: 0.1.0-alpha.5
-appVersion: "0.1.0-alpha.5"
+version: 0.1.0-alpha.6
+appVersion: "0.1.0-alpha.6"

--- a/operator/internal/controller/reconcilers/inferencepool.go
+++ b/operator/internal/controller/reconcilers/inferencepool.go
@@ -135,9 +135,18 @@ func buildInferencePool(model *llmv1alpha1.LLMModel, labels map[string]string) *
 						"number": int64(8000),
 					},
 				},
+				// Selector must exclude the EPP pod, which also carries
+				// `app.kubernetes.io/instance=<model.Name>` (it's part of
+				// the same logical deployment). Adding
+				// `app.kubernetes.io/name=llmmodel` narrows the match to
+				// just the model (vLLM) pods. Without this, the
+				// InferencePool advertises the EPP pod's IP as a backend
+				// on port 8000, where nothing is listening, and every
+				// inference request 503s with "Connection refused".
 				"selector": map[string]interface{}{
 					"matchLabels": map[string]interface{}{
 						"app.kubernetes.io/instance": model.Name,
+						"app.kubernetes.io/name":     "llmmodel",
 					},
 				},
 				"endpointPickerRef": map[string]interface{}{

--- a/operator/internal/controller/reconcilers/inferencepool_test.go
+++ b/operator/internal/controller/reconcilers/inferencepool_test.go
@@ -155,6 +155,15 @@ func TestBuildInferencePoolResources(t *testing.T) { //nolint:gocyclo // table-d
 				if instanceLabel != testPoolModelName {
 					t.Errorf("expected matchLabels app.kubernetes.io/instance=my-model, got %v", instanceLabel)
 				}
+				// Must also filter by app.kubernetes.io/name=llmmodel to
+				// exclude the EPP pod, which shares the instance label.
+				nameLabel, ok := matchLabels["app.kubernetes.io/name"]
+				if !ok {
+					t.Fatal("expected app.kubernetes.io/name in matchLabels (to exclude EPP pod)")
+				}
+				if nameLabel != "llmmodel" {
+					t.Errorf("expected matchLabels app.kubernetes.io/name=llmmodel, got %v", nameLabel)
+				}
 			},
 		},
 		{


### PR DESCRIPTION
InferencePool selector matched the EPP pod too; GIE advertised its IP as a backend on port 8000 and inference requests 503'd. Narrow selector by adding `app.kubernetes.io/name=llmmodel`.