### PR TITLE
fix(alpha.7): pass --served-model-name to vLLM

### DIFF
--- a/charts/nebari-llm-serving/Chart.yaml
+++ b/charts/nebari-llm-serving/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nebari-llm-serving
 description: Nebari software pack for serving LLMs via llm-d
 type: application
-version: 0.1.0-alpha.6
-appVersion: "0.1.0-alpha.6"
+version: 0.1.0-alpha.7
+appVersion: "0.1.0-alpha.7"

--- a/operator/internal/controller/reconcilers/modelservice.go
+++ b/operator/internal/controller/reconcilers/modelservice.go
@@ -173,8 +173,15 @@ func buildVLLMArgs(model *llmv1alpha1.LLMModel, storage *StorageResult) []string
 		dataParallelism = *model.Spec.Serving.DataParallelism
 	}
 
+	// --served-model-name makes vLLM accept the model under its public
+	// name (spec.model.name, e.g. "Qwen/Qwen3.5-35B-A3B-GPTQ-Int4") even
+	// though --model points at a local path. Without this, OpenAI-style
+	// clients that pass "model": "<name>" in the request body get a
+	// vLLM 404 "The model X does not exist" because vLLM has registered
+	// the model under the path instead.
 	args := []string{
 		"--model", storage.ModelPath,
+		"--served-model-name", model.Spec.Model.Name,
 		"--tensor-parallel-size", fmt.Sprintf("%d", tensorParallelism),
 		"--data-parallel-size", fmt.Sprintf("%d", dataParallelism),
 	}

--- a/operator/internal/controller/reconcilers/modelservice_test.go
+++ b/operator/internal/controller/reconcilers/modelservice_test.go
@@ -219,6 +219,19 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 			},
 		},
 		{
+			name:    "vllm --served-model-name is set to spec.model.name",
+			model:   defaultModel(),
+			storage: defaultStorage(),
+			cfg:     defaultConfig(),
+			check: func(t *testing.T, result *ModelServiceResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				args := result.Deployment.Spec.Template.Spec.Containers[0].Args
+				assertArgValue(t, args, "--served-model-name", "mistralai/Mistral-7B-v0.1")
+			},
+		},
+		{
 			name: "tensorParallelism explicit value used",
 			model: func() *llmv1alpha1.LLMModel {
 				m := defaultModel()


### PR DESCRIPTION
vLLM was only seeing the local path as its model name. Adds `--served-model-name=<spec.model.name>` so clients can request the model by its public name.