### PR TITLE
Add nvidia.com/gpu toleration to LLMModel requesting GPU resources

### DIFF
--- a/charts/nebari-llm-serving/crds/llmmodel-crd.yaml
+++ b/charts/nebari-llm-serving/crds/llmmodel-crd.yaml
@@ -1175,7 +1175,11 @@ spec:
                         description: nodeSelector for targeting specific node pools
                         type: object
                       tolerations:
-                        description: tolerations for GPU node scheduling
+                        description: |-
+                          Tolerations are added to the serving pod. When the model requests a GPU,
+                          the operator additionally injects a toleration for the nvidia.com/gpu taint
+                          (operator: Exists, effect: NoSchedule) so the pod can schedule onto tainted
+                          GPU nodes. Specify a toleration with key nvidia.com/gpu here to override it.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches

--- a/operator/api/v1alpha1/llmmodel_types.go
+++ b/operator/api/v1alpha1/llmmodel_types.go
@@ -193,7 +193,10 @@ type VLLMAdvancedSpec struct {
 	// extraEnv are additional environment variables on the vLLM container
 	// +optional
 	ExtraEnv []corev1.EnvVar `json:"extraEnv,omitempty"`
-	// tolerations for GPU node scheduling
+	// Tolerations are added to the serving pod. When the model requests a GPU,
+	// the operator additionally injects a toleration for the nvidia.com/gpu taint
+	// (operator: Exists, effect: NoSchedule) so the pod can schedule onto tainted
+	// GPU nodes. Specify a toleration with key nvidia.com/gpu here to override it.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// nodeSelector for targeting specific node pools

--- a/operator/config/crd/bases/llm.nebari.dev_llmmodels.yaml
+++ b/operator/config/crd/bases/llm.nebari.dev_llmmodels.yaml
@@ -1175,7 +1175,11 @@ spec:
                         description: nodeSelector for targeting specific node pools
                         type: object
                       tolerations:
-                        description: tolerations for GPU node scheduling
+                        description: |-
+                          Tolerations are added to the serving pod. When the model requests a GPU,
+                          the operator additionally injects a toleration for the nvidia.com/gpu taint
+                          (operator: Exists, effect: NoSchedule) so the pod can schedule onto tainted
+                          GPU nodes. Specify a toleration with key nvidia.com/gpu here to override it.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches

--- a/operator/internal/controller/reconcilers/modelservice.go
+++ b/operator/internal/controller/reconcilers/modelservice.go
@@ -16,12 +16,18 @@ import (
 	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
 )
 
-// modelDownloaderUserGID matches the uid/gid of the `nonroot` user in the
-// distroless base image used for the model-downloader init container
-// (gcr.io/distroless/cc-debian12:nonroot). Setting fsGroup to this value lets
-// kubelet chown PVC-backed model storage to a group the nonroot user can
-// write to.
-const modelDownloaderUserGID int64 = 65532
+const (
+	// modelDownloaderUserGID matches the uid/gid of the `nonroot` user in the
+	// distroless base image used for the model-downloader init container
+	// (gcr.io/distroless/cc-debian12:nonroot). Setting fsGroup to this value lets
+	// kubelet chown PVC-backed model storage to a group the nonroot user can
+	// write to.
+	modelDownloaderUserGID int64 = 65532
+
+	// gpuTaintKey is the taint NIC applies to GPU node groups (nvidia.com/gpu=true:NoSchedule).
+	// Pods that request a GPU must tolerate it to schedule onto those nodes.
+	gpuTaintKey = "nvidia.com/gpu"
+)
 
 // ModelServiceResources holds the Kubernetes resources for serving an LLMModel.
 type ModelServiceResources struct {
@@ -74,7 +80,7 @@ func buildDeployment(
 		ServiceAccountName: saName,
 		Containers:         []corev1.Container{container},
 		Volumes:            storage.Volumes,
-		Tolerations:        model.Spec.Advanced.VLLM.Tolerations,
+		Tolerations:        buildTolerations(model),
 		NodeSelector:       model.Spec.Advanced.VLLM.NodeSelector,
 		Affinity:           model.Spec.Advanced.VLLM.Affinity,
 		SecurityContext: &corev1.PodSecurityContext{
@@ -223,6 +229,40 @@ func buildResourceLimits(model *llmv1alpha1.LLMModel) corev1.ResourceList {
 	}
 
 	return limits
+}
+
+// buildTolerations returns the pod tolerations for a model. User-provided
+// tolerations from model.Spec.Advanced.VLLM.Tolerations are always preserved.
+// When the model requests a GPU, a toleration for the nvidia.com/gpu taint is injected
+// automatically so the pod can land on GPU nodes that NIC taints nvidia.com/gpu=true:NoSchedule. 
+// The injected toleration uses operator: Exists, which matches any taint value.
+func buildTolerations(model *llmv1alpha1.LLMModel) []corev1.Toleration {
+	// Copy to avoid mutating the model spec's underlying slice.
+	tolerations := append([]corev1.Toleration(nil), model.Spec.Advanced.VLLM.Tolerations...)
+
+	// Only inject for GPU-requesting workloads, and only if the user hasn't
+	// already specified a toleration for the GPU taint.
+	if model.Spec.Resources.GPU.Count > 0 && !tolerationsGPUTaint(tolerations) {
+		tolerations = append(tolerations, corev1.Toleration{
+			Key:      gpuTaintKey,
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
+	}
+
+	return tolerations
+}
+
+// tolerationsGPUTaint reports whether the given tolerations already cover the
+// nvidia.com/gpu taint, either via an explicit key match or an empty-key
+// (tolerate-everything) toleration.
+func tolerationsGPUTaint(tolerations []corev1.Toleration) bool {
+	for _, t := range tolerations {
+		if t.Key == gpuTaintKey || (t.Key == "" && t.Operator == corev1.TolerationOpExists) {
+			return true
+		}
+	}
+	return false
 }
 
 func buildService(model *llmv1alpha1.LLMModel, labels map[string]string) *corev1.Service {

--- a/operator/internal/controller/reconcilers/modelservice.go
+++ b/operator/internal/controller/reconcilers/modelservice.go
@@ -234,7 +234,7 @@ func buildResourceLimits(model *llmv1alpha1.LLMModel) corev1.ResourceList {
 // buildTolerations returns the pod tolerations for a model. User-provided
 // tolerations from model.Spec.Advanced.VLLM.Tolerations are always preserved.
 // When the model requests a GPU, a toleration for the nvidia.com/gpu taint is injected
-// automatically so the pod can land on GPU nodes that NIC taints nvidia.com/gpu=true:NoSchedule. 
+// automatically so the pod can land on GPU nodes that NIC taints nvidia.com/gpu=true:NoSchedule.
 // The injected toleration uses operator: Exists, which matches any taint value.
 func buildTolerations(model *llmv1alpha1.LLMModel) []corev1.Toleration {
 	// Copy to avoid mutating the model spec's underlying slice.

--- a/operator/internal/controller/reconcilers/modelservice.go
+++ b/operator/internal/controller/reconcilers/modelservice.go
@@ -24,9 +24,11 @@ const (
 	// write to.
 	modelDownloaderUserGID int64 = 65532
 
-	// gpuTaintKey is the taint NIC applies to GPU node groups (nvidia.com/gpu=true:NoSchedule).
-	// Pods that request a GPU must tolerate it to schedule onto those nodes.
-	gpuTaintKey = "nvidia.com/gpu"
+	// nvidiaGPUKey is the NVIDIA GPU identifier, used both as the extended resource
+	// the device plugin advertises (in the container's resource limits) and as the
+	// taint key NIC applies to GPU node groups (nvidia.com/gpu=true:NoSchedule).
+	// Pods that request a GPU must tolerate that taint to schedule onto those nodes.
+	nvidiaGPUKey = "nvidia.com/gpu"
 )
 
 // ModelServiceResources holds the Kubernetes resources for serving an LLMModel.
@@ -221,7 +223,7 @@ func buildResourceLimits(model *llmv1alpha1.LLMModel) corev1.ResourceList {
 
 	// Add GPU limit if count > 0
 	if model.Spec.Resources.GPU.Count > 0 {
-		limits["nvidia.com/gpu"] = *resource.NewQuantity(int64(model.Spec.Resources.GPU.Count), resource.DecimalSI)
+		limits[nvidiaGPUKey] = *resource.NewQuantity(int64(model.Spec.Resources.GPU.Count), resource.DecimalSI)
 	}
 
 	if len(limits) == 0 {
@@ -244,7 +246,7 @@ func buildTolerations(model *llmv1alpha1.LLMModel) []corev1.Toleration {
 	// already specified a toleration for the GPU taint.
 	if model.Spec.Resources.GPU.Count > 0 && !tolerationsGPUTaint(tolerations) {
 		tolerations = append(tolerations, corev1.Toleration{
-			Key:      gpuTaintKey,
+			Key:      nvidiaGPUKey,
 			Operator: corev1.TolerationOpExists,
 			Effect:   corev1.TaintEffectNoSchedule,
 		})
@@ -258,7 +260,7 @@ func buildTolerations(model *llmv1alpha1.LLMModel) []corev1.Toleration {
 // (tolerate-everything) toleration.
 func tolerationsGPUTaint(tolerations []corev1.Toleration) bool {
 	for _, t := range tolerations {
-		if t.Key == gpuTaintKey || (t.Key == "" && t.Operator == corev1.TolerationOpExists) {
+		if t.Key == nvidiaGPUKey || (t.Key == "" && t.Operator == corev1.TolerationOpExists) {
 			return true
 		}
 	}

--- a/operator/internal/controller/reconcilers/modelservice_test.go
+++ b/operator/internal/controller/reconcilers/modelservice_test.go
@@ -336,6 +336,117 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 			},
 		},
 		{
+			name: "GPU toleration auto-injected when gpu.count > 0 and no user tolerations",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultModel()
+				m.Spec.Resources.GPU = llmv1alpha1.GPUSpec{Count: 1, Type: "nvidia"}
+				return m
+			}(),
+			storage: defaultStorage(),
+			cfg:     defaultConfig(),
+			check: func(t *testing.T, result *ModelServiceResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				tolerations := result.Deployment.Spec.Template.Spec.Tolerations
+				if len(tolerations) != 1 {
+					t.Fatalf("expected 1 toleration, got %d", len(tolerations))
+				}
+				tol := tolerations[0]
+				if tol.Key != "nvidia.com/gpu" {
+					t.Errorf("expected toleration key nvidia.com/gpu, got %q", tol.Key)
+				}
+				if tol.Operator != corev1.TolerationOpExists {
+					t.Errorf("expected toleration operator Exists, got %q", tol.Operator)
+				}
+				if tol.Effect != corev1.TaintEffectNoSchedule {
+					t.Errorf("expected toleration effect NoSchedule, got %q", tol.Effect)
+				}
+			},
+		},
+		{
+			name: "GPU toleration NOT injected when gpu.count == 0",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultModel()
+				m.Spec.Resources.GPU = llmv1alpha1.GPUSpec{Count: 0, Type: "nvidia"}
+				return m
+			}(),
+			storage: defaultStorage(),
+			cfg:     defaultConfig(),
+			check: func(t *testing.T, result *ModelServiceResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				tolerations := result.Deployment.Spec.Template.Spec.Tolerations
+				if len(tolerations) != 0 {
+					t.Errorf("expected no tolerations when gpu.count == 0, got %v", tolerations)
+				}
+			},
+		},
+		{
+			name: "GPU toleration auto-injected alongside user tolerations",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultModel()
+				m.Spec.Resources.GPU = llmv1alpha1.GPUSpec{Count: 1, Type: "nvidia"}
+				m.Spec.Advanced.VLLM.Tolerations = []corev1.Toleration{
+					{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "foobar", Effect: corev1.TaintEffectNoSchedule},
+				}
+				return m
+			}(),
+			storage: defaultStorage(),
+			cfg:     defaultConfig(),
+			check: func(t *testing.T, result *ModelServiceResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				tolerations := result.Deployment.Spec.Template.Spec.Tolerations
+				if len(tolerations) != 2 {
+					t.Fatalf("expected 2 tolerations (user + auto-injected GPU), got %d", len(tolerations))
+				}
+				var hasUser, hasGPU bool
+				for _, tol := range tolerations {
+					if tol.Key == "dedicated" {
+						hasUser = true
+					}
+					if tol.Key == "nvidia.com/gpu" && tol.Operator == corev1.TolerationOpExists {
+						hasGPU = true
+					}
+				}
+				if !hasUser {
+					t.Error("expected user-provided 'dedicated' toleration to be preserved")
+				}
+				if !hasGPU {
+					t.Error("expected nvidia.com/gpu toleration to be auto-injected")
+				}
+			},
+		},
+		{
+			name: "GPU toleration NOT duplicated when user already tolerates nvidia.com/gpu",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultModel()
+				m.Spec.Resources.GPU = llmv1alpha1.GPUSpec{Count: 1, Type: "nvidia"}
+				m.Spec.Advanced.VLLM.Tolerations = []corev1.Toleration{
+					{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpEqual, Value: "true", Effect: corev1.TaintEffectNoSchedule},
+				}
+				return m
+			}(),
+			storage: defaultStorage(),
+			cfg:     defaultConfig(),
+			check: func(t *testing.T, result *ModelServiceResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				tolerations := result.Deployment.Spec.Template.Spec.Tolerations
+				if len(tolerations) != 1 {
+					t.Fatalf("expected 1 toleration (user-provided, not duplicated), got %d", len(tolerations))
+				}
+				// The user's toleration should be preserved verbatim, not overridden.
+				if tolerations[0].Operator != corev1.TolerationOpEqual || tolerations[0].Value != "true" {
+					t.Errorf("expected user toleration preserved (Equal/true), got %+v", tolerations[0])
+				}
+			},
+		},
+		{
 			name: "Advanced nodeSelector on pod spec",
 			model: func() *llmv1alpha1.LLMModel {
 				m := defaultModel()

--- a/operator/internal/controller/reconcilers/modelservice_test.go
+++ b/operator/internal/controller/reconcilers/modelservice_test.go
@@ -447,6 +447,33 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 			},
 		},
 		{
+			name: "GPU toleration NOT injected when user tolerates everything (empty-key Exists)",
+			model: func() *llmv1alpha1.LLMModel {
+				m := defaultModel()
+				m.Spec.Resources.GPU = llmv1alpha1.GPUSpec{Count: 1, Type: "nvidia"}
+				m.Spec.Advanced.VLLM.Tolerations = []corev1.Toleration{
+					{Operator: corev1.TolerationOpExists},
+				}
+				return m
+			}(),
+			storage: defaultStorage(),
+			cfg:     defaultConfig(),
+			check: func(t *testing.T, result *ModelServiceResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				tolerations := result.Deployment.Spec.Template.Spec.Tolerations
+				if len(tolerations) != 1 {
+					t.Fatalf("expected 1 toleration (tolerate-everything, not duplicated), got %d", len(tolerations))
+				}
+				// The empty-key Exists toleration already covers the GPU taint,
+				// so no nvidia.com/gpu toleration should be injected.
+				if tolerations[0].Key != "" || tolerations[0].Operator != corev1.TolerationOpExists {
+					t.Errorf("expected user tolerate-everything toleration preserved (empty key/Exists), got %+v", tolerations[0])
+				}
+			},
+		},
+		{
 			name: "Advanced nodeSelector on pod spec",
 			model: func() *llmv1alpha1.LLMModel {
 				m := defaultModel()

--- a/operator/internal/controller/reconcilers/modelservice_test.go
+++ b/operator/internal/controller/reconcilers/modelservice_test.go
@@ -172,7 +172,7 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 					t.Fatalf("unexpected error: %v", err)
 				}
 				limits := result.Deployment.Spec.Template.Spec.Containers[0].Resources.Limits
-				gpuQ, ok := limits["nvidia.com/gpu"]
+				gpuQ, ok := limits[nvidiaGPUKey]
 				if !ok {
 					t.Fatal("expected nvidia.com/gpu in resource limits")
 				}
@@ -195,7 +195,7 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 					t.Fatalf("unexpected error: %v", err)
 				}
 				limits := result.Deployment.Spec.Template.Spec.Containers[0].Resources.Limits
-				if _, ok := limits["nvidia.com/gpu"]; ok {
+				if _, ok := limits[nvidiaGPUKey]; ok {
 					t.Error("expected no nvidia.com/gpu in resource limits when gpu.count == 0")
 				}
 			},
@@ -316,7 +316,7 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 			model: func() *llmv1alpha1.LLMModel {
 				m := defaultModel()
 				m.Spec.Advanced.VLLM.Tolerations = []corev1.Toleration{
-					{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpExists},
+					{Key: nvidiaGPUKey, Operator: corev1.TolerationOpExists},
 				}
 				return m
 			}(),
@@ -330,7 +330,7 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 				if len(tolerations) != 1 {
 					t.Fatalf("expected 1 toleration, got %d", len(tolerations))
 				}
-				if tolerations[0].Key != "nvidia.com/gpu" {
+				if tolerations[0].Key != nvidiaGPUKey {
 					t.Errorf("expected toleration key nvidia.com/gpu, got %q", tolerations[0].Key)
 				}
 			},
@@ -353,7 +353,7 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 					t.Fatalf("expected 1 toleration, got %d", len(tolerations))
 				}
 				tol := tolerations[0]
-				if tol.Key != "nvidia.com/gpu" {
+				if tol.Key != nvidiaGPUKey {
 					t.Errorf("expected toleration key nvidia.com/gpu, got %q", tol.Key)
 				}
 				if tol.Operator != corev1.TolerationOpExists {
@@ -408,7 +408,7 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 					if tol.Key == "dedicated" {
 						hasUser = true
 					}
-					if tol.Key == "nvidia.com/gpu" && tol.Operator == corev1.TolerationOpExists {
+					if tol.Key == nvidiaGPUKey && tol.Operator == corev1.TolerationOpExists {
 						hasGPU = true
 					}
 				}
@@ -426,7 +426,7 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 				m := defaultModel()
 				m.Spec.Resources.GPU = llmv1alpha1.GPUSpec{Count: 1, Type: "nvidia"}
 				m.Spec.Advanced.VLLM.Tolerations = []corev1.Toleration{
-					{Key: "nvidia.com/gpu", Operator: corev1.TolerationOpEqual, Value: "true", Effect: corev1.TaintEffectNoSchedule},
+					{Key: nvidiaGPUKey, Operator: corev1.TolerationOpEqual, Value: "true", Effect: corev1.TaintEffectNoSchedule},
 				}
 				return m
 			}(),
@@ -879,7 +879,7 @@ func TestBuildModelServiceResources(t *testing.T) { //nolint:gocyclo // table-dr
 				if _, ok := limits[corev1.ResourceMemory]; !ok {
 					t.Error("expected memory in resource limits")
 				}
-				if _, ok := limits["nvidia.com/gpu"]; !ok {
+				if _, ok := limits[nvidiaGPUKey]; !ok {
 					t.Error("expected nvidia.com/gpu in resource limits")
 				}
 			},


### PR DESCRIPTION
## Closes

Closes #88

## Description

This PR makes sure a `nvidia.com/gpu` toleration is added when an `LLMModel` resource requests GPU resources. This is done because https://github.com/nebari-dev/nebari-infrastructure-core/issues/368 will add a `nvidia.com/gpu` taint to GPU node groups on AWS deployments. If the toleration does not get automatically added, no pods will get scheduled on a GPU node group.

## How to test

This should be tested on a live AWS cluster deployed via `nic`, building it off https://github.com/nebari-dev/nebari-infrastructure-core/pull/370 or just manually adding the taint to the nodegroup:

```bash
kubectl taint nodes <gpu-node> nvidia.com/gpu=true:NoSchedule
```

Then, build a new operator image off this branch and deploy the software pack to the cluster, making sure the new image is being referenced.

Afterwards, [deploy a model](https://github.com/nebari-dev/nebari-llm-serving-pack#deploy-a-model) to the cluster. The pod should get scheduled on a GPU node.



