### PR TITLE
Add healthCheck to key-manager NebariApp landing tile

### DIFF
--- a/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
@@ -44,6 +44,25 @@ spec:
     {{- with .priority }}
     priority: {{ . }}
     {{- end }}
+    {{- with .healthCheck }}
+    # Lets the Nebari landing page actively probe the key-manager and show a
+    # Healthy/Unhealthy tile instead of "Unknown". The landing webapi probes
+    # http://<service>.<namespace>:<port><path>.
+    healthCheck:
+      enabled: {{ .enabled }}
+      {{- with .path }}
+      path: {{ . | quote }}
+      {{- end }}
+      {{- with .port }}
+      port: {{ . }}
+      {{- end }}
+      {{- with .intervalSeconds }}
+      intervalSeconds: {{ . }}
+      {{- end }}
+      {{- with .timeoutSeconds }}
+      timeoutSeconds: {{ . }}
+      {{- end }}
+    {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
@@ -45,11 +45,11 @@ spec:
     priority: {{ . }}
     {{- end }}
     {{- with .healthCheck }}
-    # Lets the Nebari landing page actively probe the key-manager and show a
-    # Healthy/Unhealthy tile instead of "Unknown". The landing webapi probes
-    # http://<service>.<namespace>:<port><path>.
+    {{- /* Lets the Nebari landing page actively probe the key-manager so its
+       tile shows Healthy/Unhealthy instead of "Unknown"; the landing webapi
+       probes http://<service>.<namespace>:<port><path>. */}}
     healthCheck:
-      enabled: {{ .enabled }}
+      enabled: {{ .enabled | default false }}
       {{- with .path }}
       path: {{ . | quote }}
       {{- end }}

--- a/charts/nebari-llm-serving/values.yaml
+++ b/charts/nebari-llm-serving/values.yaml
@@ -104,6 +104,17 @@ keyManager:
       # keycloak, argocd, kubernetes) or a URL to a custom image.
       icon: "keycloak"
       priority: 100
+      # healthCheck - lets the Nebari landing page actively probe the
+      # key-manager so its tile shows Healthy/Unhealthy instead of "Unknown".
+      # The landing webapi probes http://<service>.<namespace>:<port><path>;
+      # the key-manager serves its SPA at "/" (HTTP 200, unauthenticated) while
+      # /api/* is auth-gated, so "/" is the correct probe path. port defaults to
+      # the service port (8080) when omitted.
+      healthCheck:
+        enabled: true
+        path: /
+        intervalSeconds: 30
+        timeoutSeconds: 5
 
 operator:
   image:


### PR DESCRIPTION
## Problem

On the Nebari landing page, the key-manager service tile ("AI Model Access" / "LLM API Keys") shows status **Unknown** while every other service shows **Healthy**.

## Root cause

The landing-page webapi only probes a service when its `NebariApp` declares `spec.landingPage.healthCheck` (it builds the probe as `http://<service>.<namespace>:<port><path>`). The key-manager NebariApp template never rendered a `healthCheck`, so the webapi never probed it and the tile stayed `Unknown`. Other charts (e.g. checkmaite) set this and show Healthy.

## Fix

- Render `landingPage.healthCheck` in the key-manager NebariApp template, passed through from values (with each sub-field individually guarded).
- Default it on in `values.yaml`: `enabled: true`, `path: /`, `intervalSeconds: 30`, `timeoutSeconds: 5`.

`path: /` is the correct probe target: the key-manager serves its SPA at `/` (HTTP 200, unauthenticated), whereas `/api/*` is auth-gated. `port` defaults to the service port (8080) when omitted.

## Validation

`helm template` renders the expected `healthCheck` block under `landingPage`. Probing `http://nebari-llm-serving-key-manager.<ns>:8080/` in-cluster returns HTTP 200.

## Note on existing deployments
Because the values default is `healthCheck.enabled: true`, existing deployments gain a `healthCheck` on next chart render/sync. This is intended (it's the fix). It is safe: the healthCheck is consumed by the landing-page webapi (which begins probing the key-manager), not by the key-manager pod, so reconcile is idempotent and does not restart the key-manager.