### PR TITLE
Add healthCheck to key-manager NebariApp landing tile (themed)

### DIFF
--- a/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
@@ -44,6 +44,25 @@ spec:
     {{- with .priority }}
     priority: {{ . }}
     {{- end }}
+    {{- with .healthCheck }}
+    # Lets the Nebari landing page actively probe the key-manager and show a
+    # Healthy/Unhealthy tile instead of "Unknown". The landing webapi probes
+    # http://<service>.<namespace>:<port><path>.
+    healthCheck:
+      enabled: {{ .enabled }}
+      {{- with .path }}
+      path: {{ . | quote }}
+      {{- end }}
+      {{- with .port }}
+      port: {{ . }}
+      {{- end }}
+      {{- with .intervalSeconds }}
+      intervalSeconds: {{ . }}
+      {{- end }}
+      {{- with .timeoutSeconds }}
+      timeoutSeconds: {{ . }}
+      {{- end }}
+    {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
+++ b/charts/nebari-llm-serving/templates/key-manager-nebariapp.yaml
@@ -45,11 +45,11 @@ spec:
     priority: {{ . }}
     {{- end }}
     {{- with .healthCheck }}
-    # Lets the Nebari landing page actively probe the key-manager and show a
-    # Healthy/Unhealthy tile instead of "Unknown". The landing webapi probes
-    # http://<service>.<namespace>:<port><path>.
+    {{- /* Lets the Nebari landing page actively probe the key-manager so its
+       tile shows Healthy/Unhealthy instead of "Unknown"; the landing webapi
+       probes http://<service>.<namespace>:<port><path>. */}}
     healthCheck:
-      enabled: {{ .enabled }}
+      enabled: {{ .enabled | default false }}
       {{- with .path }}
       path: {{ . | quote }}
       {{- end }}

--- a/charts/nebari-llm-serving/values.yaml
+++ b/charts/nebari-llm-serving/values.yaml
@@ -104,6 +104,17 @@ keyManager:
       # keycloak, argocd, kubernetes) or a URL to a custom image.
       icon: "keycloak"
       priority: 100
+      # healthCheck - lets the Nebari landing page actively probe the
+      # key-manager so its tile shows Healthy/Unhealthy instead of "Unknown".
+      # The landing webapi probes http://<service>.<namespace>:<port><path>;
+      # the key-manager serves its SPA at "/" (HTTP 200, unauthenticated) while
+      # /api/* is auth-gated, so "/" is the correct probe path. port defaults to
+      # the service port (8080) when omitted.
+      healthCheck:
+        enabled: true
+        path: /
+        intervalSeconds: 30
+        timeoutSeconds: 5
 
 operator:
   image:


### PR DESCRIPTION
Same fix as #101, targeted at `themed` (the branch the mystic.openteams.ai cluster currently deploys from), so the live "AI Model Access" tile stops showing **Unknown**.

Adds a `landingPage.healthCheck` passthrough to the key-manager NebariApp template and defaults it on (`enabled: true`, `path: /`, `intervalSeconds: 30`, `timeoutSeconds: 5`). `path: /` is the key-manager's unauthenticated SPA route (HTTP 200); `/api/*` is auth-gated. The landing webapi probes `http://<service>.<namespace>:<port><path>` and treats 2xx-3xx as healthy.

Validated with `helm template` + `helm lint`. See #101 for the full discussion.