### PR TITLE
fix(operator): scope API keys per-model via per-route authorization (#116)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -215,7 +215,7 @@ All resources live in the LLMModel's own namespace, which (per the validating we
 | InferencePool + EPP | Intelligent inference scheduling |
 | AIGatewayRoute (external) | External endpoint with token counting, rate limiting |
 | AIGatewayRoute (internal) | Internal endpoint with token counting, rate limiting |
-| SecurityPolicy (external) | apiKeyAuth referencing the per-model Secret in the same namespace |
+| SecurityPolicy (external) | apiKeyAuth referencing the per-model Secret (same namespace) plus a deny-by-default authorization allow-list of that model's client IDs |
 | SecurityPolicy (internal) | JWT validation with group claim matching against access.groups |
 | Secret (API keys) | Per-model API key store (created by operator, data managed by key manager) |
 | ConfigMap (key metadata) | Per-model metadata for API keys (creator, timestamp, description) |
@@ -316,7 +316,7 @@ Changes to `model.name`, `model.source`, `model.storage`, or `model.revision` re
 
 ## Dual endpoint auth
 
-Each LLMModel gets two endpoints with different auth mechanisms. Per-model hostnames ensure access control is enforced at the gateway level without request body inspection. A NetworkPolicy on model pods ensures all traffic flows through the Gateway.
+Each LLMModel gets two endpoints with different auth mechanisms. Access control is enforced at the gateway level by SecurityPolicies bound per-route: Keycloak JWT plus group authorization on the internal endpoint, and API-key authentication plus a per-model client-ID authorization allow-list on the external endpoint. (Models share one hostname and are dispatched by the `x-ai-eg-model` header, so isolation comes from the per-route policies, not from per-model hostnames.) A NetworkPolicy on model pods ensures all traffic flows through the Gateway.
 
 ### External endpoint
 
@@ -330,7 +330,16 @@ Client -> Authorization: Bearer sk-... -> Envoy AI Gateway -> apiKeyAuth Securit
 - AIGatewayRoute for token counting, rate limiting, protocol normalization
 - SecurityPolicy with `apiKeyAuth` attached to the generated HTTPRoute (same name as AIGatewayRoute), per model
 - `sanitize: true` strips the API key before forwarding to vLLM
-- `forwardClientIDHeader: X-Client-ID` passes the authenticated client ID downstream for logging and GIE flow control
+- Per-model scoping is enforced by an `authorization` block on the external
+  SecurityPolicy, not by authentication. API-key authentication is pooled across
+  the shared listener (any valid key authenticates), so the SecurityPolicy adds
+  `apiKeyAuth.forwardClientIDHeader: x-llm-client-id` and a deny-by-default
+  `authorization` rule that allows only the client IDs present in that model's
+  own api-keys Secret. A key minted for one model therefore returns 403 against
+  any other model on the listener. The operator re-renders the allow-list when
+  the key-manager mints or revokes a key, so a newly minted key activates within
+  about a minute.
+- `forwardClientIDHeader: x-llm-client-id` passes the authenticated client ID downstream for logging and GIE flow control
 - API key Secret referenced same-namespace from the SecurityPolicy (per [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59) - Envoy Gateway's APIKeyAuth does not honor cross-namespace credentialRefs)
 
 ### Internal endpoint
@@ -824,7 +833,7 @@ This restriction exists because Envoy Gateway's `SecurityPolicy.spec.apiKeyAuth.
 
 **Secret isolation**: API key Secrets live in the operator namespace with namespace-scoped RBAC. The key manager and the operator are the only components with access to these Secrets - the operator creates them, the key manager reads/updates them. SecurityPolicies in the same namespace reference them via `apiKeyAuth.credentialRefs` without crossing namespace boundaries (which Envoy Gateway does not allow for that field; see [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59)).
 
-**Gateway as security boundary**: all model access (external and internal) flows through Envoy Gateway, where auth is enforced via SecurityPolicy. The external endpoint uses apiKeyAuth with `sanitize: true` (API keys are stripped before reaching vLLM). The internal endpoint uses JWT validation against the OIDC issuer's JWKS endpoint.
+**Gateway as security boundary**: all model access (external and internal) flows through Envoy Gateway, where auth is enforced via SecurityPolicy. The external endpoint uses apiKeyAuth with `sanitize: true` (API keys are stripped before reaching vLLM) plus a per-model authorization allow-list, so a key is accepted only by the model it was minted for. The internal endpoint uses JWT validation against the OIDC issuer's JWKS endpoint.
 
 ## Open questions
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -338,8 +338,8 @@ Client -> Authorization: Bearer sk-... -> Envoy AI Gateway -> apiKeyAuth Securit
   own api-keys Secret. A key minted for one model therefore returns 403 against
   any other model on the listener. The operator re-renders the allow-list when
   the key-manager mints or revokes a key, so a newly minted key activates within
-  about a minute.
-- `forwardClientIDHeader: x-llm-client-id` passes the authenticated client ID downstream for logging and GIE flow control
+  about a minute. The forwarded `x-llm-client-id` header also reaches the
+  backend, where it serves request attribution and GIE flow control.
 - API key Secret referenced same-namespace from the SecurityPolicy (per [#59](https://github.com/nebari-dev/nebari-llm-serving-pack/issues/59) - Envoy Gateway's APIKeyAuth does not honor cross-namespace credentialRefs)
 
 ### Internal endpoint

--- a/operator/internal/controller/llmmodel_controller.go
+++ b/operator/internal/controller/llmmodel_controller.go
@@ -124,7 +124,11 @@ func (r *LLMModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// 6. Reconcile auth resources (Secret + ConfigMap, both in the model's namespace)
 	var authResources *reconcilers.AuthResources
 	if r.Config != nil {
-		authResources, err = reconcilers.BuildAuthResources(model, r.Config)
+		clientIDs, err := r.apiKeyClientIDs(ctx, model)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("reading api key client ids: %w", err)
+		}
+		authResources, err = reconcilers.BuildAuthResources(model, r.Config, clientIDs)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("building auth resources: %w", err)
 		}
@@ -260,6 +264,22 @@ func (r *LLMModelReconciler) reconcileDelete(ctx context.Context, model *llmv1al
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// apiKeyClientIDs reads the model's api-keys Secret and returns its client IDs
+// (data-key names). A missing Secret (first reconcile, before it is created)
+// yields no client IDs, which renders a deny-all external authorization until a
+// key is minted.
+func (r *LLMModelReconciler) apiKeyClientIDs(ctx context.Context, model *llmv1alpha1.LLMModel) ([]string, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: reconcilers.APIKeySecretName(model.Name), Namespace: model.Namespace}
+	if err := r.Get(ctx, key, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return reconcilers.ClientIDsFromSecret(secret), nil
 }
 
 // reconcileAuthSecretAndConfigMap creates or updates the API-key Secret and

--- a/operator/internal/controller/llmmodel_controller.go
+++ b/operator/internal/controller/llmmodel_controller.go
@@ -32,9 +32,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
 	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
@@ -759,11 +763,37 @@ func (r *LLMModelReconciler) createOrUpdateUnstructured(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *LLMModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	managedByOperator := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetLabels()["app.kubernetes.io/managed-by"] == "nebari-llm-operator"
+	})
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&llmv1alpha1.LLMModel{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.mapAPIKeySecretToModel),
+			builder.WithPredicates(managedByOperator),
+		).
 		Named("llmmodel").
 		Complete(r)
+}
+
+// mapAPIKeySecretToModel enqueues a reconcile for the LLMModel that owns an
+// api-keys Secret, so minting or revoking a key re-renders the external
+// authorization allow-list. It ignores Secrets that are not LLMModel api-keys
+// Secrets (passthrough Secrets carry app.kubernetes.io/name=passthroughmodel).
+func (r *LLMModelReconciler) mapAPIKeySecretToModel(_ context.Context, obj client.Object) []reconcile.Request {
+	labels := obj.GetLabels()
+	if labels["app.kubernetes.io/name"] != "llmmodel" {
+		return nil
+	}
+	name := labels["llm.nebari.dev/model-name"]
+	if name == "" {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: obj.GetNamespace()},
+	}}
 }

--- a/operator/internal/controller/passthroughmodel_controller.go
+++ b/operator/internal/controller/passthroughmodel_controller.go
@@ -29,9 +29,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
 	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
@@ -356,8 +360,33 @@ func boolOrDefaultStatus(b *bool) bool {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PassthroughModelReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	managedByOperator := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetLabels()["app.kubernetes.io/managed-by"] == "nebari-llm-operator"
+	})
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&llmv1alpha1.PassthroughModel{}).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(r.mapAPIKeySecretToModel),
+			builder.WithPredicates(managedByOperator),
+		).
 		Named("passthroughmodel").
 		Complete(r)
+}
+
+// mapAPIKeySecretToModel enqueues a reconcile for the PassthroughModel that owns
+// an api-keys Secret. It ignores Secrets that are not passthrough api-keys
+// Secrets (served-model Secrets carry app.kubernetes.io/name=llmmodel).
+func (r *PassthroughModelReconciler) mapAPIKeySecretToModel(_ context.Context, obj client.Object) []reconcile.Request {
+	labels := obj.GetLabels()
+	if labels["app.kubernetes.io/name"] != "passthroughmodel" {
+		return nil
+	}
+	name := labels["llm.nebari.dev/model-name"]
+	if name == "" {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: name, Namespace: obj.GetNamespace()},
+	}}
 }

--- a/operator/internal/controller/passthroughmodel_controller.go
+++ b/operator/internal/controller/passthroughmodel_controller.go
@@ -89,7 +89,11 @@ func (r *PassthroughModelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	resources, err := reconcilers.BuildPassthroughResources(pm, r.Config)
+	clientIDs, err := r.apiKeyClientIDs(ctx, pm)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("reading api key client ids: %w", err)
+	}
+	resources, err := reconcilers.BuildPassthroughResources(pm, r.Config, clientIDs)
 	if err != nil {
 		// Surface the build failure as a condition so `kubectl describe`
 		// explains the Error phase rather than only the reconcile log.
@@ -163,6 +167,21 @@ func (r *PassthroughModelReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{RequeueAfter: time.Minute}, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+// apiKeyClientIDs reads the passthrough model's api-keys Secret and returns its
+// client IDs (data-key names). A missing Secret yields no client IDs (deny-all
+// external authorization until a key is minted).
+func (r *PassthroughModelReconciler) apiKeyClientIDs(ctx context.Context, pm *llmv1alpha1.PassthroughModel) ([]string, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: reconcilers.APIKeySecretName(pm.Name), Namespace: pm.Namespace}
+	if err := r.Get(ctx, key, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return reconcilers.ClientIDsFromSecret(secret), nil
 }
 
 // reconcileDelete cleans up the auth resources (no owner references) and

--- a/operator/internal/controller/reconcilers/auth.go
+++ b/operator/internal/controller/reconcilers/auth.go
@@ -11,6 +11,14 @@ import (
 	"github.com/nebari-dev/nebari-llm-serving-pack/operator/internal/config"
 )
 
+// apiKeyClientIDHeader is the request header Envoy Gateway populates with the
+// authenticated API key's client ID (the api-keys Secret data-key name). The
+// per-route authorization rule matches this header against the model's own
+// client IDs so a key minted for one model cannot call another. The api_key_auth
+// filter (order 6) runs before the RBAC/authorization filter (order 301), so the
+// header is present when authorization evaluates.
+const apiKeyClientIDHeader = "x-llm-client-id"
+
 // AuthResources holds all auth-related resources for an LLMModel. All
 // resources live in the LLMModel's own namespace - the operator no longer
 // uses a separate api-keys namespace because Envoy Gateway's
@@ -29,7 +37,7 @@ type AuthResources struct {
 // BuildAuthResources is a pure function that computes all auth-related Kubernetes resources
 // for the given LLMModel: API key Secret, metadata ConfigMap, and SecurityPolicies.
 // All resources are placed in the LLMModel's own namespace.
-func BuildAuthResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig) (*AuthResources, error) {
+func BuildAuthResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig, clientIDs []string) (*AuthResources, error) {
 	result := &AuthResources{}
 
 	labels := authResourceLabels(model)
@@ -38,7 +46,7 @@ func BuildAuthResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig)
 	result.APIKeyMetadataCM = buildAPIKeyMetadataConfigMap(model, labels)
 
 	if boolOrDefault(model.Spec.Endpoints.External.Enabled, true) {
-		result.ExternalSecurityPolicy = buildExternalSecurityPolicy(model)
+		result.ExternalSecurityPolicy = buildExternalSecurityPolicy(model, clientIDs)
 	}
 
 	if boolOrDefault(model.Spec.Endpoints.Internal.Enabled, true) {
@@ -100,13 +108,14 @@ func buildAPIKeyMetadataConfigMap(model *llmv1alpha1.LLMModel, labels map[string
 	}
 }
 
-func buildExternalSecurityPolicy(model *llmv1alpha1.LLMModel) *unstructured.Unstructured {
+func buildExternalSecurityPolicy(model *llmv1alpha1.LLMModel, clientIDs []string) *unstructured.Unstructured {
 	return buildAPIKeyAuthSecurityPolicy(
 		model.Name+"-external-auth",
 		model.Namespace,
 		labelsToInterface(StandardLabels(model)),
 		model.Name+"-external",
 		APIKeySecretName(model.Name),
+		clientIDs,
 	)
 }
 
@@ -114,7 +123,7 @@ func buildExternalSecurityPolicy(model *llmv1alpha1.LLMModel) *unstructured.Unst
 // external HTTPRoute behind per-user API keys. Shared between the LLMModel
 // and PassthroughModel reconcilers so both endpoint types present the same
 // client UX (Authorization header carrying a key from the api-keys Secret).
-func buildAPIKeyAuthSecurityPolicy(name, namespace string, labels map[string]interface{}, routeName, secretName string) *unstructured.Unstructured {
+func buildAPIKeyAuthSecurityPolicy(name, namespace string, labels map[string]interface{}, routeName, secretName string, clientIDs []string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "gateway.envoyproxy.io/v1alpha1",
@@ -151,13 +160,53 @@ func buildAPIKeyAuthSecurityPolicy(name, namespace string, labels map[string]int
 							},
 						},
 					},
-					// TODO: Add sanitize:true and forwardClientIDHeader when minimum
-					// Envoy Gateway version is bumped to v1.7+ (these fields are not
-					// in v1.3 SecurityPolicy CRD)
+					// forwardClientIDHeader surfaces the matched credential's
+					// client ID to the authorization filter (and upstream).
+					// sanitize strips the API key before the backend sees it.
+					"forwardClientIDHeader": apiKeyClientIDHeader,
+					"sanitize":              true,
+				},
+				// Authentication (apiKeyAuth) is pooled per listener: any valid
+				// key on the shared listener authenticates. Authorization is
+				// per-route and is what scopes a key to its model: deny by
+				// default, allow only this model's client IDs.
+				"authorization": buildAPIKeyAuthorization(clientIDs),
+			},
+		},
+	}
+}
+
+// buildAPIKeyAuthorization returns a deny-by-default authorization block that
+// allows only the given client IDs (matched on the forwarded client-ID header).
+// With no client IDs it returns deny-all (no Allow rule), which is correct for a
+// model that has no keys minted yet: every request, including one bearing a key
+// valid for a different model on the shared listener, is denied.
+func buildAPIKeyAuthorization(clientIDs []string) map[string]interface{} {
+	authz := map[string]interface{}{
+		"defaultAction": "Deny",
+	}
+	if len(clientIDs) == 0 {
+		return authz
+	}
+	values := make([]interface{}, 0, len(clientIDs))
+	for _, id := range clientIDs {
+		values = append(values, id)
+	}
+	authz["rules"] = []interface{}{
+		map[string]interface{}{
+			"name":   "allow-model-clients",
+			"action": "Allow",
+			"principal": map[string]interface{}{
+				"headers": []interface{}{
+					map[string]interface{}{
+						"name":   apiKeyClientIDHeader,
+						"values": values,
+					},
 				},
 			},
 		},
 	}
+	return authz
 }
 
 func buildInternalSecurityPolicy(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig) *unstructured.Unstructured {

--- a/operator/internal/controller/reconcilers/auth.go
+++ b/operator/internal/controller/reconcilers/auth.go
@@ -1,6 +1,8 @@
 package reconcilers
 
 import (
+	"sort"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -44,6 +46,23 @@ func BuildAuthResources(model *llmv1alpha1.LLMModel, cfg *config.OperatorConfig)
 	}
 
 	return result, nil
+}
+
+// ClientIDsFromSecret returns the sorted data-key names of an api-keys Secret.
+// Each data-key name is an Envoy Gateway client ID (one per minted API key;
+// the key-manager writes secret.Data[clientID] = apiKey). The list is sorted so
+// SecurityPolicy rendering is deterministic across reconciles. A nil or
+// dataless Secret yields an empty slice.
+func ClientIDsFromSecret(secret *corev1.Secret) []string {
+	if secret == nil {
+		return []string{}
+	}
+	ids := make([]string, 0, len(secret.Data))
+	for k := range secret.Data {
+		ids = append(ids, k)
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 // authResourceLabels returns the labels applied to the API-key Secret and

--- a/operator/internal/controller/reconcilers/auth_test.go
+++ b/operator/internal/controller/reconcilers/auth_test.go
@@ -98,10 +98,11 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		model *llmv1alpha1.LLMModel
-		cfg   *config.OperatorConfig
-		check func(t *testing.T, result *AuthResources, err error)
+		name      string
+		model     *llmv1alpha1.LLMModel
+		cfg       *config.OperatorConfig
+		clientIDs []string
+		check     func(t *testing.T, result *AuthResources, err error)
 	}{
 		{
 			name:  "API key Secret: correct name and namespace",
@@ -254,8 +255,86 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 				}
 			},
 		},
-		// NOTE: sanitize and forwardClientIDHeader are Envoy Gateway v1.7+ features.
-		// Tests for these fields will be added when minimum EG version is bumped.
+		{
+			name:      "External SecurityPolicy: sets forwardClientIDHeader and sanitize",
+			model:     defaultAuthModel(),
+			cfg:       defaultAuthConfig(),
+			clientIDs: []string{"user-chuck-1"},
+			check: func(t *testing.T, result *AuthResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				spec := result.ExternalSecurityPolicy.Object["spec"].(map[string]interface{})
+				apiKeyAuth := spec["apiKeyAuth"].(map[string]interface{})
+				if apiKeyAuth["forwardClientIDHeader"] != "x-llm-client-id" {
+					t.Errorf("expected forwardClientIDHeader=x-llm-client-id, got %v", apiKeyAuth["forwardClientIDHeader"])
+				}
+				if apiKeyAuth["sanitize"] != true {
+					t.Errorf("expected sanitize=true, got %v", apiKeyAuth["sanitize"])
+				}
+			},
+		},
+		{
+			name:      "External SecurityPolicy: authorization allow-list is exactly this model's client IDs",
+			model:     defaultAuthModel(),
+			cfg:       defaultAuthConfig(),
+			clientIDs: []string{"user-alice-1", "user-chuck-2"},
+			check: func(t *testing.T, result *AuthResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				spec := result.ExternalSecurityPolicy.Object["spec"].(map[string]interface{})
+				authz, ok := spec["authorization"].(map[string]interface{})
+				if !ok {
+					t.Fatal("expected authorization block on external SecurityPolicy")
+				}
+				if authz["defaultAction"] != "Deny" {
+					t.Errorf("expected defaultAction=Deny, got %v", authz["defaultAction"])
+				}
+				rules := authz["rules"].([]interface{})
+				if len(rules) != 1 {
+					t.Fatalf("expected 1 rule, got %d", len(rules))
+				}
+				principal := rules[0].(map[string]interface{})["principal"].(map[string]interface{})
+				headers := principal["headers"].([]interface{})
+				hm := headers[0].(map[string]interface{})
+				if hm["name"] != "x-llm-client-id" {
+					t.Errorf("expected header name x-llm-client-id, got %v", hm["name"])
+				}
+				values := hm["values"].([]interface{})
+				if len(values) != 2 || values[0] != "user-alice-1" || values[1] != "user-chuck-2" {
+					t.Errorf("expected values=[user-alice-1 user-chuck-2], got %v", values)
+				}
+				// A foreign client ID must NOT be in the allow-list.
+				for _, v := range values {
+					if v == "user-bob-9" {
+						t.Errorf("foreign client id leaked into allow-list: %v", values)
+					}
+				}
+			},
+		},
+		{
+			name:      "External SecurityPolicy: zero client IDs renders deny-all with no allow rule",
+			model:     defaultAuthModel(),
+			cfg:       defaultAuthConfig(),
+			clientIDs: nil,
+			check: func(t *testing.T, result *AuthResources, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				spec := result.ExternalSecurityPolicy.Object["spec"].(map[string]interface{})
+				authz, ok := spec["authorization"].(map[string]interface{})
+				if !ok {
+					t.Fatal("expected authorization block even with zero client IDs")
+				}
+				if authz["defaultAction"] != "Deny" {
+					t.Errorf("expected defaultAction=Deny, got %v", authz["defaultAction"])
+				}
+				if _, present := authz["rules"]; present {
+					t.Errorf("expected no rules key for zero client IDs, got %v", authz["rules"])
+				}
+			},
+		},
 		{
 			name:  "External SecurityPolicy: extractFrom headers includes Authorization",
 			model: defaultAuthModel(),
@@ -618,7 +697,7 @@ func TestBuildAuthResources(t *testing.T) { //nolint:gocyclo // table-driven tes
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result, err := BuildAuthResources(tt.model, tt.cfg)
+			result, err := BuildAuthResources(tt.model, tt.cfg, tt.clientIDs)
 			tt.check(t, result, err)
 		})
 	}

--- a/operator/internal/controller/reconcilers/auth_test.go
+++ b/operator/internal/controller/reconcilers/auth_test.go
@@ -3,6 +3,7 @@ package reconcilers
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	llmv1alpha1 "github.com/nebari-dev/nebari-llm-serving-pack/operator/api/v1alpha1"
@@ -51,6 +52,45 @@ func defaultAuthConfig() *config.OperatorConfig {
 		// pure-build tests are not entangled with the legacy-cleanup
 		// branch.
 		APIKeysNamespace: "",
+	}
+}
+
+func TestClientIDsFromSecret(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		secret *corev1.Secret
+		want   []string
+	}{
+		{name: "nil secret", secret: nil, want: []string{}},
+		{
+			name:   "empty data",
+			secret: &corev1.Secret{Data: map[string][]byte{}},
+			want:   []string{},
+		},
+		{
+			name: "keys returned sorted",
+			secret: &corev1.Secret{Data: map[string][]byte{
+				"user-chuck-2": []byte("k2"),
+				"user-alice-1": []byte("k1"),
+				"user-chuck-1": []byte("k0"),
+			}},
+			want: []string{"user-alice-1", "user-chuck-1", "user-chuck-2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClientIDsFromSecret(tt.secret)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
 }
 

--- a/operator/internal/controller/reconcilers/passthrough.go
+++ b/operator/internal/controller/reconcilers/passthrough.go
@@ -45,7 +45,7 @@ func PassthroughStandardLabels(pm *llmv1alpha1.PassthroughModel) map[string]stri
 // BuildPassthroughResources is a pure function that computes every resource
 // for the given PassthroughModel. No serving, storage, or scheduling
 // resources are involved; the provider serves the models, we route to it.
-func BuildPassthroughResources(pm *llmv1alpha1.PassthroughModel, cfg *config.OperatorConfig) (*PassthroughResources, error) {
+func BuildPassthroughResources(pm *llmv1alpha1.PassthroughModel, cfg *config.OperatorConfig, clientIDs []string) (*PassthroughResources, error) {
 	labels := PassthroughStandardLabels(pm)
 	authLabels := map[string]string{}
 	for k, v := range labels {
@@ -98,6 +98,7 @@ func BuildPassthroughResources(pm *llmv1alpha1.PassthroughModel, cfg *config.Ope
 			labelsToInterface(labels),
 			pm.Name+"-external",
 			APIKeySecretName(pm.Name),
+			clientIDs,
 		)
 	}
 

--- a/operator/internal/controller/reconcilers/passthrough_test.go
+++ b/operator/internal/controller/reconcilers/passthrough_test.go
@@ -85,7 +85,7 @@ func routeRules(t *testing.T, route *unstructured.Unstructured) []interface{} {
 
 func TestBuildPassthroughResourcesProviderPlumbing(t *testing.T) {
 	pm := testPassthroughModel()
-	res, err := BuildPassthroughResources(pm, testPassthroughConfig())
+	res, err := BuildPassthroughResources(pm, testPassthroughConfig(), nil)
 	if err != nil {
 		t.Fatalf("BuildPassthroughResources returned error: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestBuildPassthroughResourcesProviderPlumbing(t *testing.T) {
 
 func TestBuildPassthroughResourcesKeySecretAndConfigMap(t *testing.T) {
 	pm := testPassthroughModel()
-	res, err := BuildPassthroughResources(pm, testPassthroughConfig())
+	res, err := BuildPassthroughResources(pm, testPassthroughConfig(), nil)
 	if err != nil {
 		t.Fatalf("BuildPassthroughResources returned error: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestBuildPassthroughResourcesRoutes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			pm := testPassthroughModel()
 			tt.mutate(pm)
-			res, err := BuildPassthroughResources(pm, testPassthroughConfig())
+			res, err := BuildPassthroughResources(pm, testPassthroughConfig(), nil)
 			if err != nil {
 				t.Fatalf("BuildPassthroughResources returned error: %v", err)
 			}
@@ -288,7 +288,7 @@ func TestBuildPassthroughResourcesRoutes(t *testing.T) {
 func TestBuildPassthroughRouteDetails(t *testing.T) {
 	pm := testPassthroughModel()
 	cfg := testPassthroughConfig()
-	res, err := BuildPassthroughResources(pm, cfg)
+	res, err := BuildPassthroughResources(pm, cfg, nil)
 	if err != nil {
 		t.Fatalf("BuildPassthroughResources returned error: %v", err)
 	}
@@ -381,7 +381,7 @@ func TestBuildPassthroughRouteDetails(t *testing.T) {
 func TestBuildPassthroughResourcesSecurityPolicies(t *testing.T) {
 	pm := testPassthroughModel()
 	cfg := testPassthroughConfig()
-	res, err := BuildPassthroughResources(pm, cfg)
+	res, err := BuildPassthroughResources(pm, cfg, nil)
 	if err != nil {
 		t.Fatalf("BuildPassthroughResources returned error: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestBuildPassthroughResourcesSecurityPolicies(t *testing.T) {
 	t.Run("public access drops authorization", func(t *testing.T) {
 		pub := testPassthroughModel()
 		pub.Spec.Access = llmv1alpha1.AccessSpec{Public: ptr.To(true)}
-		pubRes, err := BuildPassthroughResources(pub, cfg)
+		pubRes, err := BuildPassthroughResources(pub, cfg, nil)
 		if err != nil {
 			t.Fatalf("BuildPassthroughResources returned error: %v", err)
 		}
@@ -440,4 +440,38 @@ func TestBuildPassthroughResourcesSecurityPolicies(t *testing.T) {
 			t.Error("public access must not render an authorization block")
 		}
 	})
+}
+
+func TestBuildPassthroughExternalAuthorization(t *testing.T) {
+	t.Parallel()
+	pm := testPassthroughModel()
+	cfg := testPassthroughConfig()
+
+	withKeys, err := BuildPassthroughResources(pm, cfg, []string{"user-chuck-1"})
+	if err != nil {
+		t.Fatalf("BuildPassthroughResources returned error: %v", err)
+	}
+	spec := withKeys.ExternalSecurityPolicy.Object["spec"].(map[string]interface{})
+	apiKeyAuth := spec["apiKeyAuth"].(map[string]interface{})
+	if apiKeyAuth["forwardClientIDHeader"] != "x-llm-client-id" || apiKeyAuth["sanitize"] != true {
+		t.Errorf("expected forwardClientIDHeader/sanitize set, got %v", apiKeyAuth)
+	}
+	authz := spec["authorization"].(map[string]interface{})
+	if authz["defaultAction"] != "Deny" {
+		t.Errorf("expected defaultAction=Deny, got %v", authz["defaultAction"])
+	}
+	rules := authz["rules"].([]interface{})
+	values := rules[0].(map[string]interface{})["principal"].(map[string]interface{})["headers"].([]interface{})[0].(map[string]interface{})["values"].([]interface{})
+	if len(values) != 1 || values[0] != "user-chuck-1" {
+		t.Errorf("expected values=[user-chuck-1], got %v", values)
+	}
+
+	noKeys, err := BuildPassthroughResources(pm, cfg, nil)
+	if err != nil {
+		t.Fatalf("BuildPassthroughResources returned error: %v", err)
+	}
+	authzNo := noKeys.ExternalSecurityPolicy.Object["spec"].(map[string]interface{})["authorization"].(map[string]interface{})
+	if _, present := authzNo["rules"]; present {
+		t.Errorf("expected deny-all (no rules) for zero client IDs, got %v", authzNo["rules"])
+	}
 }


### PR DESCRIPTION
## What this fixes

Closes #116. Today any valid API key works for every model on the shared external gateway listener (`llm.<baseDomain>`). Envoy Gateway pools the `apiKeyAuth` credentials from every per-model SecurityPolicy on that listener into one set, so a key minted for a cheap model authenticates against an expensive or restricted one just by changing the `model` field. Group checks at mint time still hold, but there was no request-time per-model enforcement on the API-key path.

## Approach

The isolation belongs in authorization, not authentication. Each model's external SecurityPolicy now gets:

- `apiKeyAuth.forwardClientIDHeader: x-llm-client-id` and `sanitize: true`
- an `authorization` block: `defaultAction: Deny` plus one Allow rule listing only the client IDs present in that model's own api-keys Secret

A foreign key still passes the pooled authentication, but it forwards a client ID that is not in the target route's allow-list, so authorization returns 403. The single shared listener and single TLS certificate are unchanged.

The operator reads each model's api-keys Secret to build the allow-list and watches that Secret (label-filtered, no owner reference) so minting or revoking a key re-renders the policy within about a minute. Both served (`LLMModel`) and passthrough (`PassthroughModel`) models are covered through the shared builder.

### Note on the Envoy Gateway version

The `auth.go` TODO claimed `forwardClientIDHeader`/`sanitize` need EG v1.7+. That is not correct: both fields exist as of EG v1.5.7 / v1.6.0, and `Authorization.Principal.Headers` (exact header matching) is available too. The dev stack is already on EG v1.6.7 (via #115), and AI Gateway v0.5 already forces an EG v1.6.x floor, so this needs no version bump. The stale TODO is removed.

## Behavior

With a key minted only into model A's Secret:

- A's key against model A: 200
- A's key against model B: 403 (was 200)
- invalid key against any model: 401 (authentication still active)
- a model with an empty Secret, called with another model's valid key: 403

## Blocked by #115

This is stacked on #115 (which aligns the dev stack to EG v1.6.7). The PR is based on `feat/local-dev-passthrough-and-ui-devmode` so the diff shows only this change; it should merge after #115. GitHub will retarget it to `main` once #115 lands.

## Test plan

Automated (passing):

- `buildExternalSecurityPolicy` / passthrough builder render `forwardClientIDHeader`, `sanitize: true`, and `authorization: defaultAction: Deny`
- the Allow rule lists exactly the model's own client IDs and excludes a foreign client ID
- zero client IDs render deny-all with no Allow rule (the empty-Secret case)
- both `LLMModel` and `PassthroughModel` paths covered
- the internal/JWT authorization path is unchanged and still passing

Deferred (needs the EG v1.6.7 dev stack from #115, so not yet run): the end-to-end curl matrix on a live cluster (the 200/403/401 cases above, plus revoke and fresh-mint timing). This is tracked and will be run once #115 merges and the stack is available.

Docs in `docs/design.md` are updated to describe the per-model authorization and to correct a stale claim that per-model hostnames enforced access control.
