### PR TITLE
chore: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -10,8 +10,8 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      # https://github.com/actions/add-to-project/releases/tag/v1.0.2
-      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e
+      # https://github.com/actions/add-to-project/releases/tag/v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd
         with:
           project-url: ${{ vars.PROJECT_BOARD_URL }}
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -18,10 +18,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_PREFIX }}/operator
           tags: |
@@ -39,7 +39,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push operator image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: operator/
           file: operator/Dockerfile
@@ -54,10 +54,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_PREFIX }}/model-downloader
           tags: |
@@ -75,7 +75,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push model-downloader image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: model-downloader/
           file: model-downloader/Dockerfile
@@ -90,10 +90,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_PREFIX }}/key-manager
           tags: |
@@ -111,7 +111,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push key-manager image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: key-manager/Dockerfile

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,15 +11,15 @@ jobs:
     name: Lint operator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: operator/go.mod
           cache-dependency-path: operator/go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.4.0
           working-directory: operator
@@ -28,15 +28,15 @@ jobs:
     name: Lint key-manager
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: key-manager/go.mod
           cache-dependency-path: key-manager/go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.4.0
           working-directory: key-manager
@@ -45,10 +45,10 @@ jobs:
     name: Lint Helm chart
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Lint chart
         run: helm lint charts/nebari-llm-serving/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,9 +11,9 @@ jobs:
     name: Test operator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: operator/go.mod
           cache-dependency-path: operator/go.sum
@@ -26,9 +26,9 @@ jobs:
     name: Test key-manager
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: key-manager/go.mod
           cache-dependency-path: key-manager/go.sum


### PR DESCRIPTION
## Summary

Bumps all GitHub Actions under `.github/workflows/` to their latest stable majors so they run on **Node 24**, ahead of GitHub's [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (runners default to Node 24 on 2026-06-16; Node 20 fully removed Fall 2026).

Closes #118.

## Changes

| Action | Old | New |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/setup-go` | v5 | v6 |
| `actions/add-to-project` | v1.0.2 (SHA) | v2.0.0 (SHA) |
| `docker/login-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `docker/build-push-action` | v6 | v7 |
| `golangci/golangci-lint-action` | v7 | v9 |
| `azure/setup-helm` | v4 | v5 |

Notes:
- `golangci-lint-action@v9` drops golangci-lint v1 support; the workflow already pins `version: v2.4.0`, so no config changes are needed.
- `add-to-project` was already SHA-pinned, so it stays SHA-pinned (repointed to the v2.0.0 commit) to preserve the existing convention.

## Out of scope

- No changes to workflow logic, job topology, or triggers — version bump only.
- Migrating other actions to SHA pins / Dependabot is a separate follow-up.
- Runtimes used *inside* jobs (Go, Helm, etc.) are unchanged beyond clearing action deprecations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)